### PR TITLE
Removing retryable-http library

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,12 @@ To build the code from source, you'll need, at the very least, the `go` and `git
 install dependencies:
 ```
 go get github.com/google/subcommands
-go get golang.org/x/sync/semaphore
 go install github.com/google/subcommands
+go get golang.org/x/sync/semaphore
+go get github.com/pbnjay/memory
 go get github.com/dnanexus/dxda
 go install github.com/dnanexus/dxda
-go install github.com/dnanexus/dxda/cmd/dx-download-
+go install github.com/dnanexus/dxda/cmd/dx-download-agent
 ```
 
 Assuming the go directory is `/go`, clone the code with:

--- a/dx_describe.go
+++ b/dx_describe.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 
 	// The dxda package has the get-environment code
 	"github.com/dnanexus/dxda"
-	"github.com/hashicorp/go-retryablehttp" // use http libraries from hashicorp for implement retry logic
 )
 
 // Limit on the number of objects that the bulk-describe API can take
@@ -98,7 +98,7 @@ type DxDescribeRaw struct {
 // Describe a large number of file-ids in one API call.
 func submit(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	dxEnv *dxda.DXEnvironment,
 	fileIds []string) (map[string]DxDescribeDataObject, error) {
 
@@ -175,7 +175,7 @@ func submit(
 
 func DxDescribeBulkObjects(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	dxEnv *dxda.DXEnvironment,
 	objIds []string) (map[string]DxDescribeDataObject, error) {
 	var gMap = make(map[string]DxDescribeDataObject)
@@ -233,7 +233,7 @@ type DxListFolder struct {
 // back a list of object-ids and sub-directories.
 func listFolder(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	dxEnv *dxda.DXEnvironment,
 	projectId string,
 	dir string) (*DxListFolder, error) {
@@ -271,7 +271,7 @@ func listFolder(
 
 func DxDescribeFolder(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	dxEnv *dxda.DXEnvironment,
 	projectId string,
 	folder string) (*DxFolder, error) {
@@ -337,7 +337,7 @@ func projectPermissionsToInt(perm string) int {
 
 func DxDescribeProject(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	dxEnv *dxda.DXEnvironment,
 	projectId string) (*DxDescribePrj, error) {
 
@@ -387,7 +387,7 @@ func DxDescribeProject(
 // Describe just one object. Retrieve state even if the object is not closed.
 func DxDescribe(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	dxEnv *dxda.DXEnvironment,
 	objId string) (DxDescribeDataObject, error) {
 	var objectIds []string

--- a/dx_find.go
+++ b/dx_find.go
@@ -37,7 +37,8 @@ func DxFindProject(
 		return "", err
 	}
 
-	httpClient := dxda.NewHttpClient(false)
+	//httpClient := dxda.NewHttpClient(false)
+	httpClient := dxda.NewHttpClient()
 	repJs, err := dxda.DxAPI(ctx, httpClient, NumRetriesDefault, dxEnv, "system/findProjects", string(payload))
 	if err != nil {
 		return "", err

--- a/dx_ops.go
+++ b/dx_ops.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"encoding/hex"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
 	"github.com/dnanexus/dxda"
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 const (
@@ -52,7 +52,7 @@ type ReplyFolderNew struct {
 
 func (ops *DxOps) DxFolderNew(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	projId string,
 	folder string) error {
 	if ops.options.Verbose {
@@ -99,7 +99,7 @@ type ReplyFolderRemove struct {
 
 func (ops *DxOps) DxFolderRemove(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	projId string,
 	folder string) error {
 	if ops.options.Verbose {
@@ -146,7 +146,7 @@ type ReplyRemoveObjects struct {
 
 func (ops *DxOps) DxRemoveObjects(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	projId string,
 	objectIds []string) error {
 	if ops.options.Verbose {
@@ -194,7 +194,7 @@ type ReplyNewFile struct {
 
 func (ops *DxOps) DxFileNew(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	nonceStr string,
 	projId string,
 	fname string,
@@ -230,7 +230,7 @@ func (ops *DxOps) DxFileNew(
 
 func (ops *DxOps) DxFileCloseAndWait(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	fid string) error {
 	if ops.options.Verbose {
 		ops.log("file close-and-wait %s", fid)
@@ -305,7 +305,7 @@ func (ops *DxOps) isRetryableUploadError(err error) bool {
 
 func (ops *DxOps) DxFileUploadPart(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	fileId string,
 	index int,
 	data []byte) error {
@@ -371,7 +371,7 @@ type ReplyRename struct {
 //  rename a data object
 func (ops *DxOps) DxRename(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	projId string,
 	fileId string,
 	newName string) error {
@@ -419,7 +419,7 @@ type ReplyMove struct {
 // Moves the specified data objects and folders to a destination folder in the same container.
 func (ops *DxOps) DxMove(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	projId      string,
 	objectIds []string,
 	folders   []string,
@@ -464,7 +464,7 @@ type ReplyRenameFolder struct {
 
 func (ops *DxOps) DxRenameFolder(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	projId string,
 	folder string,
 	newName string) error {
@@ -511,7 +511,7 @@ type ReplyClone struct {
 
 func (ops *DxOps) DxClone(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	srcProjId string,
 	srcId string,
 	destProjId string,
@@ -566,7 +566,7 @@ type ReplySetProperties struct {
 
 func (ops *DxOps) DxSetProperties(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	projId string,
 	objId string,
 	props map[string](*string)) error {
@@ -607,7 +607,7 @@ type ReplyAddTags struct {
 
 func (ops *DxOps) DxAddTags(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	projId string,
 	objId string,
 	tags []string) error {
@@ -649,7 +649,7 @@ type ReplyRemoveTags struct {
 
 func (ops *DxOps) DxRemoveTags(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient *http.Client,
 	projId string,
 	objId string,
 	tags []string) error {

--- a/manifest.go
+++ b/manifest.go
@@ -141,7 +141,7 @@ func MakeManifestFromProjectIds(
 	dxEnv dxda.DXEnvironment,
 	projectIds []string) (*Manifest, error) {
 	// describe the projects, retrieve metadata for them
-	tmpHttpClient := dxda.NewHttpClient(false)
+	tmpHttpClient := dxda.NewHttpClient()
 	projDescs := make(map[string]DxDescribePrj)
 	for _, pId := range projectIds {
 		pDesc, err := DxDescribeProject(ctx, tmpHttpClient, &dxEnv, pId)
@@ -296,7 +296,7 @@ It is a node in the middle, which is illegal.
 }
 
 func (m *Manifest) FillInMissingFields(ctx context.Context, dxEnv dxda.DXEnvironment) error {
-	tmpHttpClient := dxda.NewHttpClient(false)
+	tmpHttpClient := dxda.NewHttpClient()
 
 	// Make a list of all the files that are missing details
 	fileIds := make(map[string]bool)

--- a/test/local/manifest_test.sh
+++ b/test/local/manifest_test.sh
@@ -1,10 +1,33 @@
+######################################################################
+# global variables
+
 CRNT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-function manifest_test {
-    local mountpoint=${HOME}/MNT
-    local projName="dxfuse_test_data"
-    local dxfuse="$GOPATH/bin/dxfuse"
+mountpoint=${HOME}/MNT
+projName="dxfuse_test_data"
+dxfuse="$GOPATH/bin/dxfuse"
+teardown_complete=0
 
+######################################################################
+
+# cleanup sequence
+function teardown {
+    if [[ $teardown_complete == 1 ]]; then
+        return
+    fi
+    teardown_complete=1
+
+    rm -f cmd_results.txt
+
+    echo "unmounting dxfuse"
+    cd $HOME
+    sudo umount $mountpoint
+}
+
+# trap any errors and cleanup
+trap teardown EXIT
+
+function manifest_test {
     mkdir -p $mountpoint
 
     sudo -E $dxfuse -uid $(id -u) -gid $(id -g) $mountpoint $CRNT_DIR/two_files.json
@@ -21,5 +44,6 @@ function manifest_test {
         echo "file $full_path has incorrect content"
         exit 1
     fi
-    sudo umount $mountpoint
+
+    teardown
 }

--- a/util.go
+++ b/util.go
@@ -4,10 +4,9 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"time"
-
-	"github.com/hashicorp/go-retryablehttp"
 
 	"github.com/jacobsa/fuse/fuseops"
 )
@@ -221,7 +220,7 @@ type DirtyFileInfo struct {
 // A handle used when operating on a filesystem
 // operation. We normally need a transaction and an http client.
 type OpHandle struct {
-	httpClient *retryablehttp.Client
+	httpClient *http.Client
 	txn        *sql.Tx
 	err         error
 }


### PR DESCRIPTION
Replaciung the retryablehttp library with direct usage of the golang net/http library.