### PR TITLE
Memory mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,9 @@ For OSX you will need to install [OSXFUSE](http://osxfuse.github.com/). Note tha
 
 If a project appears empty, or is missing files, it could be that the dnanexus token does not have permissions for it. Try to see if you can do `dx ls YOUR_PROJECT:`.
 
-If you do not set the `uid` and `gid` options then creating hard links will fail on Linux. This is because it will fail the kernel's permissions check.
-
 There is no natural match for DNAnexus applets and workflows, so they are presented as block devices. They do not behave like block devices, but the shell colors them differently from files and directories.
 
-Mmap doesn't work all that well with FUSE ([stack overflow issue](https://stackoverflow.com/questions/46839807/mmap-no-such-device)). For example, trying to memory-map (mmap) a file with python causes an error.
+FUSE does not support memory mappings shared between processes ([explanation](https://github.com/jacobsa/fuse/issues/82)). This is the location in the [Linux kernel](https://elixir.bootlin.com/linux/v5.6/source/fs/fuse/file.c#L2306) where this is not allowed. For example, trying to memory-map (mmap) a file with python causes an error.
 
 ```
 >>> import mmap
@@ -237,7 +235,7 @@ Traceback (most recent call last):
   OSError: [Errno 19] No such device
 ```
 
-A workaround is to make the mapping private:
+If the mapping is private to a single process then it does work. For example:
 
 ```
 >>> import mmap

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## v0.22
 - Use github actions for continuous integration (CI/CD)
+- Eliminate the use of `sudo` for starting up the filesystem. Normal user permissions are now sufficient to start and stop the filesystem. This assumes that the fuse device (`/dev/fuse`) is open for read/write access to regular users.
 
 ## v0.21
 - Fixed bug that occurs when a data object has properties or tags that include the apostrophe (\`) character.

--- a/dxfuse.go
+++ b/dxfuse.go
@@ -152,7 +152,7 @@ func NewDxfuse(
 	databaseFile := dxfuseBaseDir + "/" + DatabaseFile
 	fsys.log("Removing old version of the database (%s)", databaseFile)
 	if err := os.RemoveAll(databaseFile); err != nil {
-		fsys.log("error removing old database %b", err)
+		fsys.log("error removing old database %s", err.Error())
 		os.Exit(1)
 	}
 

--- a/test/local/file_map_test.py
+++ b/test/local/file_map_test.py
@@ -1,0 +1,8 @@
+import mmap
+import os
+
+home_dir = os.getenv("HOME")
+extras_json = "{}/MNT/dxfuse_test_data/mini/extras.json".format(home_dir)
+fd = open(extras_json, 'rb')
+mmap.mmap(fd.fileno(), 0, mmap.PROT_READ)
+fd.readline()

--- a/test/local/mm.go
+++ b/test/local/mm.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"golang.org/x/exp/mmap"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type Config struct {
+	filename string
+	verbose bool
+}
+
+var progName = filepath.Base(os.Args[0])
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage:\n")
+	fmt.Fprintf(os.Stderr, "    %s filename\n", progName)
+	flag.PrintDefaults()
+}
+
+var (
+	help = flag.Bool("help", false, "display program options")
+	verbose = flag.Bool("verbose", false, "Enable verbose debugging")
+)
+
+
+func parseCmdLineArgs() Config {
+	if *help {
+		usage()
+		os.Exit(0)
+	}
+
+	numArgs := flag.NArg()
+	if numArgs > 1 {
+		usage()
+		os.Exit(2)
+	}
+
+	return Config{
+		filename : flag.Arg(0),
+		verbose : *verbose,
+	}
+}
+
+func main() {
+	// parse command line options
+	flag.Usage = usage
+	flag.Parse()
+	cfg := parseCmdLineArgs()
+
+	reader, err := mmap.Open(cfg.filename)
+	if err != nil {
+		fmt.Printf("Error mmaping file %s (%s)\n", cfg.filename, err.Error())
+		os.Exit(1)
+	}
+	defer reader.Close()
+
+	// read the data
+	dataLen := reader.Len()
+	buf := make([]byte, dataLen)
+	recvLen, err := reader.ReadAt(buf, 0)
+	if err != nil {
+		fmt.Printf("Error reading mmaped file %s (%s)\n", cfg.filename, err.Error())
+		os.Exit(1)
+	}
+	if recvLen != dataLen {
+		fmt.Printf("recvLen != dataLen (%d, %d)\n", recvLen, dataLen)
+		os.Exit(1)
+	}
+	fmt.Printf("content=%s\n", buf)
+}


### PR DESCRIPTION
Adding a good explanation for why shared memory mappings do not work with any FUSE filesystem. Suggesting to the user that PRIVATE mapping do work instead.