### PR TITLE
DEVEX-1675 Do not allow more than one concurrent sync command

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,6 +51,7 @@ jobs:
           go get github.com/pbnjay/memory
           go get github.com/dnanexus/dxda
           go get -u github.com/jacobsa/fuse
+          go get golang.org/x/sync/semaphore
 
           mkdir -p /go/src/github.com/dnanexus
           cp -r $GITHUB_WORKSPACE /go/src/github.com/dnanexus

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ install dependencies:
 go get github.com/pbnjay/memory
 go get github.com/dnanexus/dxda
 go get -u github.com/jacobsa/fuse
+go get golang.org/x/sync/semaphore
 ```
 
 Assuming the go directory is `/go`, clone the code with:

--- a/cmd_client.go
+++ b/cmd_client.go
@@ -27,7 +27,7 @@ func (client *CmdClient) Sync() {
 	var reply bool
 	err = rpcClient.Call("CmdServerBox.GetLine", "sync", &reply)
 	if err != nil {
-		fmt.Printf("sync error: %s", err.Error())
+		fmt.Printf("sync error: %s\n", err.Error())
 		os.Exit(1)
 	}
 }

--- a/cmd_server.go
+++ b/cmd_server.go
@@ -1,14 +1,17 @@
 /* Accept commands from the dxfuse_tools program. The only command
 * right now is sync, but this is the place to implement additional
 * ones to come in the future.
-*/
+ */
 package dxfuse
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
 	"net/rpc"
+
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -17,7 +20,7 @@ const (
 )
 
 type CmdServer struct {
-	options  Options
+	options Options
 	sybx    *SyncDbDx
 	inbound *net.TCPListener
 }
@@ -30,8 +33,8 @@ type CmdServerBox struct {
 func NewCmdServer(options Options, sybx *SyncDbDx) *CmdServer {
 	cmdServer := &CmdServer{
 		options: options,
-		sybx : sybx,
-		inbound : nil,
+		sybx:    sybx,
+		inbound: nil,
 	}
 	return cmdServer
 }
@@ -54,7 +57,7 @@ func (cmdSrv *CmdServer) Init() {
 	cmdSrv.inbound = inbound
 
 	cmdSrvBox := &CmdServerBox{
-		cmdSrv : cmdSrv,
+		cmdSrv: cmdSrv,
 	}
 	rpc.Register(cmdSrvBox)
 	go rpc.Accept(inbound)
@@ -66,6 +69,9 @@ func (cmdSrv *CmdServer) Close() {
 	cmdSrv.inbound.Close()
 }
 
+// Only allow one sync operation at a time
+var sem = semaphore.NewWeighted(1)
+
 // Note: all export functions from this module have to have this format.
 // Nothing else will work with the RPC package.
 func (box *CmdServerBox) GetLine(arg string, reply *bool) error {
@@ -73,6 +79,13 @@ func (box *CmdServerBox) GetLine(arg string, reply *bool) error {
 	cmdSrv.log("Received line %s", arg)
 	switch arg {
 	case "sync":
+		// Error out if another sync operation has been run by the cmd client
+		// https://stackoverflow.com/questions/45208536/good-way-to-return-on-locked-mutex-in-go
+		if !sem.TryAcquire(1) {
+			cmdSrv.log("Failed to acquire sempahore")
+			return errors.New("another sync operation is already running")
+		}
+		defer sem.Release(1)
 		cmdSrv.sybx.CmdSync()
 	default:
 		cmdSrv.log("Unknown command")

--- a/cmd_server.go
+++ b/cmd_server.go
@@ -82,7 +82,7 @@ func (box *CmdServerBox) GetLine(arg string, reply *bool) error {
 		// Error out if another sync operation has been run by the cmd client
 		// https://stackoverflow.com/questions/45208536/good-way-to-return-on-locked-mutex-in-go
 		if !sem.TryAcquire(1) {
-			cmdSrv.log("Failed to acquire sempahore")
+			cmdSrv.log("Rejecting sync operation as another is already runnning")
 			return errors.New("another sync operation is already running")
 		}
 		defer sem.Release(1)

--- a/test/local/local.sh
+++ b/test/local/local.sh
@@ -24,3 +24,6 @@ faux_dirs
 
 source $CRNT_DIR/file_overwrite.sh
 file_overwrite
+
+source $CRNT_DIR/sync_concurrency_test.sh
+sync_concurrency_test

--- a/test/local/sync_concurrency_test.sh
+++ b/test/local/sync_concurrency_test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+######################################################################
+# global variables
+
+CRNT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+mountpoint=${HOME}/MNT
+projName="dxfuse_test_data"
+dxfuse="$GOPATH/bin/dxfuse"
+teardown_complete=0
+
+writeable_dir=""
+######################################################################
+
+# cleanup sequence
+function teardown {
+    if [[ $teardown_complete == 1 ]]; then
+        return
+    fi
+    teardown_complete=1
+    rm -f 50MB
+    dx rm -r $projName:/$writeable_dir
+    echo "unmounting dxfuse"
+    cd $HOME
+    fusermount -u $mountpoint
+}
+
+# trap any errors and cleanup
+trap teardown EXIT
+
+# Ensure that only one sync command may run at a time
+function sync_concurrency_test {
+    mkdir -p $mountpoint
+    $dxfuse $mountpoint $projName
+    sleep 1
+    dd if=/dev/urandom of=50MB bs=1M count=50
+    writeable_dir=$(cat /dev/urandom | env LC_CTYPE=C LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 12 | head -n 1)
+    dx mkdir $projName:/$writeable_dir
+    # Start copy and dxfuse sync
+    cp 50MB $mountpoint/$projName/$writeable_dir &
+    CP_PID=$!
+    $dxfuse -sync &
+    SYNC_PID=$!
+    sleep 1
+    # Additional sync commands fail until the above sync completes
+    sync_output=$($dxfuse -sync 2>&1)
+
+    if echo "$sync_output" | grep -q "another sync operation is already running"; then
+        wait $CP_PID
+        wait $SYNC_PID
+        echo "$sync_output"
+        # Sync should function again now that the first sync command has completed
+        $dxfuse -sync
+    else
+        echo "Second sync operation did not error out"
+        exit 1
+    fi
+
+    teardown
+}


### PR DESCRIPTION
Return an error to the cmd client if attempting to execute `dxfuse -sync` if another sync operation is currently running.