### PR TITLE
DEVEX-1823 readahead and 255k dir limit

### DIFF
--- a/dxfuse.go
+++ b/dxfuse.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// namespace for xattrs
-	XATTR_TAG = "tag"
+	XATTR_TAG  = "tag"
 	XATTR_PROP = "prop"
 	XATTR_BASE = "base"
 )
@@ -48,7 +48,7 @@ type Filesys struct {
 
 	// a pool of http clients, for short requests, such as file creation,
 	// or file describe.
-	httpClientPool    chan(*http.Client)
+	httpClientPool chan (*http.Client)
 
 	// metadata database
 	mdb *MetadataDb
@@ -70,11 +70,11 @@ type Filesys struct {
 
 	// all open files
 	fhCounter uint64
-	fhTable map[fuseops.HandleID]*FileHandle
+	fhTable   map[fuseops.HandleID]*FileHandle
 
 	// all open directories
 	dhCounter uint64
-	dhTable map[fuseops.HandleID]*DirHandle
+	dhTable   map[fuseops.HandleID]*DirHandle
 
 	tmpFileCounter uint64
 
@@ -98,20 +98,20 @@ const (
 type FileHandle struct {
 	// a lock allowing multiple readers or a single writer.
 	accessMode int
-	inode     int64
-	size      int64   // this is up-to-date only for remote files
-	hid       fuseops.HandleID
+	inode      int64
+	size       int64 // this is up-to-date only for remote files
+	hid        fuseops.HandleID
 
 	// URL used for downloading file ranges.
 	// Used for read-only files.
-	url      *DxDownloadURL
+	url *DxDownloadURL
 
 	// A file-descriptor for files with a local copy
-	fd       *os.File
+	fd *os.File
 }
 
 type DirHandle struct {
-	d Dir
+	d       Dir
 	entries []fuseutil.Dirent
 }
 
@@ -122,24 +122,24 @@ func NewDxfuse(
 
 	// initialize a pool of http-clients.
 	httpIoPool := make(chan *http.Client, HttpClientPoolSize)
-	for i:=0; i < HttpClientPoolSize; i++ {
+	for i := 0; i < HttpClientPoolSize; i++ {
 		httpIoPool <- dxda.NewHttpClient()
 	}
 
 	dxfuseBaseDir := MakeFSBaseDir()
 	fsys := &Filesys{
-		dxEnv : dxEnv,
-		options: options,
-		mutex : &sync.Mutex{},
-		httpClientPool: httpIoPool,
-		ops : NewDxOps(dxEnv, options),
-		fhCounter : 1,
-		fhTable : make(map[fuseops.HandleID]*FileHandle),
-		dhCounter : 1,
-		dhTable : make(map[fuseops.HandleID]*DirHandle),
-		tmpFileCounter : 0,
-		shutdownCalled : false,
-		createdFilesDir : dxfuseBaseDir + "/" + CreatedFilesDir,
+		dxEnv:           dxEnv,
+		options:         options,
+		mutex:           &sync.Mutex{},
+		httpClientPool:  httpIoPool,
+		ops:             NewDxOps(dxEnv, options),
+		fhCounter:       1,
+		fhTable:         make(map[fuseops.HandleID]*FileHandle),
+		dhCounter:       1,
+		dhTable:         make(map[fuseops.HandleID]*DirHandle),
+		tmpFileCounter:  0,
+		shutdownCalled:  false,
+		createdFilesDir: dxfuseBaseDir + "/" + CreatedFilesDir,
 	}
 
 	// Create a directory for new files
@@ -176,10 +176,10 @@ func NewDxfuse(
 	fsys.pgs = NewPrefetchGlobalState(options.VerboseLevel, dxEnv)
 
 	// describe all the projects, we need their upload parameters
-	httpClient := <- fsys.httpClientPool
+	httpClient := <-fsys.httpClientPool
 	defer func() {
 		fsys.httpClientPool <- httpClient
-	} ()
+	}()
 
 	if options.ReadOnly {
 		// we don't need the file upload module
@@ -264,12 +264,12 @@ func (fsys *Filesys) opOpen() *OpHandle {
 	if err != nil {
 		log.Panic("Could not open transaction")
 	}
-	httpClient := <- fsys.httpClientPool
+	httpClient := <-fsys.httpClientPool
 
 	return &OpHandle{
-		httpClient : httpClient,
-		txn : txn,
-		err : nil,
+		httpClient: httpClient,
+		txn:        txn,
+		err:        nil,
 	}
 }
 
@@ -280,9 +280,9 @@ func (fsys *Filesys) opOpenNoHttpClient() *OpHandle {
 	}
 
 	return &OpHandle{
-		httpClient : nil,
-		txn : txn,
-		err : nil,
+		httpClient: nil,
+		txn:        txn,
+		err:        nil,
 	}
 }
 
@@ -473,7 +473,7 @@ func (fsys *Filesys) SetInodeAttributes(ctx context.Context, op *fuseops.SetInod
 		attrs.Mtime = *op.Mtime
 	}
 	// we don't handle atime
-	err = fsys.mdb.UpdateFileAttrs(ctx, oph, file.Inode, int64(attrs.Size), attrs.Mtime, &attrs.Mode);
+	err = fsys.mdb.UpdateFileAttrs(ctx, oph, file.Inode, int64(attrs.Size), attrs.Mtime, &attrs.Mode)
 	if err != nil {
 		fsys.log("database error in OpenFile %s", err.Error())
 		return fuse.EIO
@@ -598,7 +598,7 @@ func (fsys *Filesys) MkDir(ctx context.Context, op *fuseops.MkDirOp) error {
 		nowSeconds,
 		nowSeconds,
 		mode,
-		parentDir.FullPath + "/" + op.Name)
+		parentDir.FullPath+"/"+op.Name)
 	if err != nil {
 		fsys.log("database error in MkDir")
 		return fuse.EIO
@@ -617,14 +617,13 @@ func (fsys *Filesys) MkDir(ctx context.Context, op *fuseops.MkDirOp) error {
 	}
 	tWindow := fsys.calcExpirationTime(childAttrs)
 	op.Entry = fuseops.ChildInodeEntry{
-		Child : fuseops.InodeID(dnode),
-		Attributes : childAttrs,
-		AttributesExpiration : tWindow,
-		EntryExpiration : tWindow,
+		Child:                fuseops.InodeID(dnode),
+		Attributes:           childAttrs,
+		AttributesExpiration: tWindow,
+		EntryExpiration:      tWindow,
 	}
 	return nil
 }
-
 
 func (fsys *Filesys) RmDir(ctx context.Context, op *fuseops.RmDirOp) error {
 	fsys.mutex.Lock()
@@ -795,10 +794,10 @@ func (fsys *Filesys) CreateFile(ctx context.Context, op *fuseops.CreateFileOp) e
 	// soon change. We are writing new content into the file.
 	tWindow := fsys.calcExpirationTime(childAttrs)
 	op.Entry = fuseops.ChildInodeEntry{
-		Child : fuseops.InodeID(file.Inode),
-		Attributes : childAttrs,
-		AttributesExpiration : tWindow,
-		EntryExpiration : tWindow,
+		Child:                fuseops.InodeID(file.Inode),
+		Attributes:           childAttrs,
+		AttributesExpiration: tWindow,
+		EntryExpiration:      tWindow,
 	}
 
 	// Note: we can't open the file in exclusive mode, because another process
@@ -810,11 +809,11 @@ func (fsys *Filesys) CreateFile(ctx context.Context, op *fuseops.CreateFileOp) e
 	}
 
 	fh := FileHandle{
-		accessMode : AM_RW_Local,
-		inode : file.Inode,
-		size : file.Size,
-		url : nil,
-		fd : writer,
+		accessMode: AM_RW_Local,
+		inode:      file.Inode,
+		size:       file.Size,
+		url:        nil,
+		fd:         writer,
 	}
 	op.Handle = fsys.insertIntoFileHandleTable(&fh)
 	return nil
@@ -1144,9 +1143,9 @@ func (fsys *Filesys) readEntireDir(ctx context.Context, oph *OpHandle, dir Dir) 
 		}
 		dirEnt := fuseutil.Dirent{
 			Offset: 0,
-			Inode : fuseops.InodeID(oDesc.Inode),
-			Name : oname,
-			Type : dType,
+			Inode:  fuseops.InodeID(oDesc.Inode),
+			Name:   oname,
+			Type:   dType,
 		}
 		dEntries = append(dEntries, dirEnt)
 	}
@@ -1155,9 +1154,9 @@ func (fsys *Filesys) readEntireDir(ctx context.Context, oph *OpHandle, dir Dir) 
 	for subDirName, dirDesc := range subdirs {
 		dirEnt := fuseutil.Dirent{
 			Offset: 0,
-			Inode : fuseops.InodeID(dirDesc.Inode),
-			Name : subDirName,
-			Type : fuseutil.DT_Directory,
+			Inode:  fuseops.InodeID(dirDesc.Inode),
+			Name:   subDirName,
+			Type:   fuseutil.DT_Directory,
 		}
 		dEntries = append(dEntries, dirEnt)
 	}
@@ -1178,7 +1177,6 @@ func (fsys *Filesys) readEntireDir(ctx context.Context, oph *OpHandle, dir Dir) 
 
 	return dEntries, nil
 }
-
 
 // OpenDir return nil error allows open dir
 // COMMON for drivers
@@ -1206,7 +1204,7 @@ func (fsys *Filesys) OpenDir(ctx context.Context, op *fuseops.OpenDirOp) error {
 	}
 
 	dh := &DirHandle{
-		d : dir,
+		d:       dir,
 		entries: dentries,
 	}
 	op.Handle = fsys.insertIntoDirHandleTable(dh)
@@ -1253,7 +1251,6 @@ func (fsys *Filesys) ReleaseDirHandle(ctx context.Context, op *fuseops.ReleaseDi
 	return nil
 }
 
-
 // ===
 // File handling
 //
@@ -1272,10 +1269,10 @@ func (fsys *Filesys) openRegularFile(
 		}
 		fh := &FileHandle{
 			accessMode: AM_RW_Local,
-			inode : f.Inode,
-			size : f.Size,
-			url: nil,
-			fd : reader,
+			inode:      f.Inode,
+			size:       f.Size,
+			url:        nil,
+			fd:         reader,
 		}
 
 		return fh, nil
@@ -1297,10 +1294,10 @@ func (fsys *Filesys) openRegularFile(
 
 	fh := &FileHandle{
 		accessMode: AM_RO_Remote,
-		inode : f.Inode,
-		size : f.Size,
-		url: &u,
-		fd : nil,
+		inode:      f.Inode,
+		size:       f.Size,
+		url:        &u,
+		fd:         nil,
 	}
 
 	return fh, nil
@@ -1364,14 +1361,14 @@ func (fsys *Filesys) OpenFile(ctx context.Context, op *fuseops.OpenFileOp) error
 		// directly. There is no need to generate a preauthenticated
 		// URL.
 		fh = &FileHandle{
-			accessMode : AM_RO_Remote,
-			inode : file.Inode,
-			size : file.Size,
-			url : &DxDownloadURL{
-				URL : file.Symlink,
-				Headers : nil,
+			accessMode: AM_RO_Remote,
+			inode:      file.Inode,
+			size:       file.Size,
+			url: &DxDownloadURL{
+				URL:     file.Symlink,
+				Headers: nil,
 			},
-			fd : nil,
+			fd: nil,
 		}
 	default:
 		// can't open an applet/workflow/etc.
@@ -1390,7 +1387,6 @@ func (fsys *Filesys) OpenFile(ctx context.Context, op *fuseops.OpenFileOp) error
 	}
 	return nil
 }
-
 
 func (fsys *Filesys) getWritableFD(ctx context.Context, handle fuseops.HandleID) (*os.File, error) {
 	fsys.mutex.Lock()
@@ -1411,7 +1407,6 @@ func (fsys *Filesys) getWritableFD(ctx context.Context, handle fuseops.HandleID)
 	}
 	return fh.fd, nil
 }
-
 
 // read a remote immutable file
 //
@@ -1458,7 +1453,7 @@ func (fsys *Filesys) readRemoteFile(ctx context.Context, op *fuseops.ReadFileOp,
 	}
 
 	// Take an http client from the pool. Return it when done.
-	httpClient := <- fsys.httpClientPool
+	httpClient := <-fsys.httpClientPool
 	err := dxda.DxHttpRequestData(
 		ctx,
 		httpClient,
@@ -1476,7 +1471,7 @@ func (fsys *Filesys) readRemoteFile(ctx context.Context, op *fuseops.ReadFileOp,
 func (fsys *Filesys) ReadFile(ctx context.Context, op *fuseops.ReadFileOp) error {
 	// Here, we start from the file handle
 	fsys.mutex.Lock()
-	fh,ok := fsys.fhTable[op.Handle]
+	fh, ok := fsys.fhTable[op.Handle]
 	if !ok {
 		// invalid file handle. It doesn't exist in the table
 		fsys.mutex.Unlock()
@@ -1518,7 +1513,7 @@ func (fsys *Filesys) prepareFileForWrite(ctx context.Context, op *fuseops.WriteF
 	fsys.mutex.Lock()
 	defer fsys.mutex.Unlock()
 
-	fh,ok := fsys.fhTable[op.Handle]
+	fh, ok := fsys.fhTable[op.Handle]
 	if !ok {
 		// invalid file handle. It doesn't exist in the table
 		return nil, fuse.EINVAL
@@ -1596,7 +1591,7 @@ func (fsys *Filesys) WriteFile(ctx context.Context, op *fuseops.WriteFileOp) err
 
 	// Try to efficiently calculate the size and mtime, instead
 	// of doing a filesystem call.
-	fSize := MaxInt64(op.Offset + int64(nBytes), fh.size)
+	fSize := MaxInt64(op.Offset+int64(nBytes), fh.size)
 	mtime := time.Now()
 
 	// Update the file attributes in the database (size, mtime)
@@ -1729,7 +1724,7 @@ func (fsys *Filesys) xattrParseName(name string) (string, string, error) {
 		return "", "", fuse.EINVAL
 	}
 	namespace := name[:prefixLen]
-	attrName := name[len(namespace) + 1 : ]
+	attrName := name[len(namespace)+1:]
 	return namespace, attrName, nil
 }
 
@@ -1809,7 +1804,6 @@ func (fsys *Filesys) RemoveXattr(ctx context.Context, op *fuseops.RemoveXattrOp)
 	return nil
 }
 
-
 func (fsys *Filesys) getXattrFill(op *fuseops.GetXattrOp, val_str string) error {
 	value := []byte(val_str)
 	op.BytesRead = len(value)
@@ -1829,7 +1823,7 @@ func (fsys *Filesys) GetXattr(ctx context.Context, op *fuseops.GetXattrOp) error
 	oph := fsys.opOpen()
 	defer fsys.opClose(oph)
 
-	if fsys.options.Verbose {
+	if fsys.options.VerboseLevel > 1 {
 		fsys.log("GetXattr %d", op.Inode)
 	}
 
@@ -1874,7 +1868,7 @@ func (fsys *Filesys) GetXattr(ctx context.Context, op *fuseops.GetXattrOp) error
 			return fsys.getXattrFill(op, file.State)
 		case "archivalState":
 			return fsys.getXattrFill(op, file.ArchivalState)
-		case "id" :
+		case "id":
 			return fsys.getXattrFill(op, file.Id)
 		}
 	}
@@ -1903,14 +1897,14 @@ func (fsys *Filesys) ListXattr(ctx context.Context, op *fuseops.ListXattrOp) err
 	// collect all the properties into one array
 	var xattrKeys []string
 	for _, tag := range file.Tags {
-		xattrKeys = append(xattrKeys, XATTR_TAG + "." + tag)
+		xattrKeys = append(xattrKeys, XATTR_TAG+"."+tag)
 	}
 	for key, _ := range file.Properties {
-		xattrKeys = append(xattrKeys, XATTR_PROP + "." + key)
+		xattrKeys = append(xattrKeys, XATTR_PROP+"."+key)
 	}
 	// Special attributes
-	for _, key := range []string{ "state", "archivalState", "id"} {
-		xattrKeys = append(xattrKeys, XATTR_BASE + "." + key)
+	for _, key := range []string{"state", "archivalState", "id"} {
+		xattrKeys = append(xattrKeys, XATTR_BASE+"."+key)
 	}
 	if fsys.options.Verbose {
 		fsys.log("attribute keys: %v", xattrKeys)
@@ -1924,7 +1918,7 @@ func (fsys *Filesys) ListXattr(ctx context.Context, op *fuseops.ListXattrOp) err
 
 		if len(dst) >= keyLen {
 			copy(dst, key)
-			dst[keyLen-1] = 0  // null terminate the string
+			dst[keyLen-1] = 0 // null terminate the string
 			dst = dst[keyLen:]
 		} else if len(op.Dst) != 0 {
 			return syscall.ERANGE

--- a/prefetch.go
+++ b/prefetch.go
@@ -1077,7 +1077,9 @@ func (pgs *PrefetchGlobalState) CacheLookup(hid fuseops.HandleID, startOfs int64
 		return 0
 
 	case PFM_PREFETCH_IN_PROGRESS:
-		pfm.log("pfm prefetch in progress")
+		if pgs.verbose {
+			pfm.log("pfm prefetch in progress")
+		}
 		// ongoing prefetch IO
 		pgs.markAccessedAndMaybeStartPrefetch(pfm, startOfs, endOfs)
 		retCode, len := pgs.getDataFromCache(pfm, startOfs, endOfs, data)

--- a/prefetch.go
+++ b/prefetch.go
@@ -890,7 +890,6 @@ func (pgs *PrefetchGlobalState) markAccessedAndMaybeStartPrefetch(
 	// the next chunk(s)
 
 	if pfm.state == PFM_DETECT_SEQ {
-		pfm.log("set to pfm in progress")
 		pfm.state = PFM_PREFETCH_IN_PROGRESS
 	}
 

--- a/prefetch.go
+++ b/prefetch.go
@@ -1076,9 +1076,6 @@ func (pgs *PrefetchGlobalState) CacheLookup(hid fuseops.HandleID, startOfs int64
 		return 0
 
 	case PFM_PREFETCH_IN_PROGRESS:
-		if pgs.verbose {
-			pfm.log("pfm prefetch in progress")
-		}
 		// ongoing prefetch IO
 		pgs.markAccessedAndMaybeStartPrefetch(pfm, startOfs, endOfs)
 		retCode, len := pgs.getDataFromCache(pfm, startOfs, endOfs, data)

--- a/prefetch.go
+++ b/prefetch.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"io/ioutil"
+	"log"
 	"math/bits"
 	"net/http"
 	"os"
@@ -26,8 +26,8 @@ const (
 	periodicTime = 30 * time.Second
 	slowIoThresh = 60 // when does a slow IO become worth reporting
 
-	prefetchMinIoSize = (256 * KiB)   // threshold for deciding the file is sequentially accessed
-	prefetchIoFactor = 4
+	prefetchMinIoSize = (256 * KiB) // threshold for deciding the file is sequentially accessed
+	prefetchIoFactor  = 4
 
 	numSlotsInChunk = 64
 
@@ -38,7 +38,7 @@ const (
 	// maximum number of prefetch threads, regardless of machine size
 	maxNumPrefetchThreads = 32
 
-	minFileSize = 1 * MiB     // do not track files smaller than this size
+	minFileSize = 1 * MiB // do not track files smaller than this size
 
 	// An prefetch request time limit
 	readRequestTimeout = 90 * time.Second
@@ -46,95 +46,95 @@ const (
 
 // enumerated type for the state of a PFM (file metadata)
 const (
-	PFM_NIL = 1                  // No IOs have been seen yet, cache is empty
-	PFM_DETECT_SEQ = 2           // First accesses, detecting if access is sequential
+	PFM_NIL                  = 1 // No IOs have been seen yet, cache is empty
+	PFM_DETECT_SEQ           = 2 // First accesses, detecting if access is sequential
 	PFM_PREFETCH_IN_PROGRESS = 3 // prefetch is ongoing
-	PFM_EOF = 4                  // reached the end of the file
+	PFM_EOF                  = 4 // reached the end of the file
 )
 
 // state of an io-vector
 const (
-	IOV_HOLE = 1      // empty
+	IOV_HOLE      = 1 // empty
 	IOV_IN_FLIGHT = 2 // in progress
-	IOV_DONE = 3      // completed successfully
-	IOV_ERRORED = 4   // completed with an error
+	IOV_DONE      = 3 // completed successfully
+	IOV_ERRORED   = 4 // completed with an error
 )
 
 // A request that one of the IO-threads will pick up
 type IoReq struct {
-	hid         fuseops.HandleID
-	inode       int64
-	size       int64
-	url         DxDownloadURL
+	hid   fuseops.HandleID
+	inode int64
+	size  int64
+	url   DxDownloadURL
 
-	ioSize      int64   // The io size
-	startByte   int64   // start byte, counting from the beginning of the file.
-	endByte     int64
+	ioSize    int64 // The io size
+	startByte int64 // start byte, counting from the beginning of the file.
+	endByte   int64
 
-	id          uint64  // a unique id for this IO
+	id uint64 // a unique id for this IO
 }
 
 type Iovec struct {
-	ioSize         int64   // The io size
-	startByte      int64   // start byte, counting from the beginning of the file.
-	endByte        int64
-	touched        uint64  // mark the areas that have been accessed by the user
-	data         []byte
+	ioSize    int64 // The io size
+	startByte int64 // start byte, counting from the beginning of the file.
+	endByte   int64
+	touched   uint64 // mark the areas that have been accessed by the user
+	data      []byte
 
 	// io-vector statue (ongoing, done, errored)
-	state          int
+	state int
 
 	// Allow user reads to wait until prefetch IO complete
-	cond                *sync.Cond
+	cond *sync.Cond
 }
 
 // A cache of all the data retrieved from the platform, for one file.
 // It is a contiguous range of chunks. All IOs are the same size.
 type Cache struct {
-	prefetchIoSize     int64  // size of the IO to issue when prefetching
-	maxNumIovecs       int
+	prefetchIoSize int64 // size of the IO to issue when prefetching
+	maxNumIovecs   int
 
-	startByte          int64
-	endByte            int64
-	iovecs             [](*Iovec)
+	startByte int64
+	endByte   int64
+	iovecs    [](*Iovec)
 }
 
 type MeasureWindow struct {
-	timestamp            time.Time
-	numIOs               int
-	numBytesPrefetched   int64
-	numPrefetchIOs       int
+	timestamp          time.Time
+	numIOs             int
+	numBytesPrefetched int64
+	numPrefetchIOs     int
 }
 
 type PrefetchFileMetadata struct {
-	mutex                sync.Mutex
+	mutex sync.Mutex
 
 	// the file being tracked
-	hid                  fuseops.HandleID
-	inode                int64
-	id                   string
-	size                 int64
-	url                  DxDownloadURL
-	state                int
+	hid   fuseops.HandleID
+	inode int64
+	id    string
+	size  int64
+	url   DxDownloadURL
+	state int
 
-	lastIoTimestamp      time.Time  // Last time an IO hit this file
-	hiUserAccessOfs      int64      // highest file offset accessed by the user
-	mw                   MeasureWindow // statistics for stream
+	lastIoTimestamp time.Time     // Last time an IO hit this file
+	hiUserAccessOfs int64         // highest file offset accessed by the user
+	mw              MeasureWindow // statistics for stream
 
 	// cached io vectors.
 	// The assumption is that the user is accessing the last io-vector.
 	// If this assumption isn't true, prefetch is ineffective. The algorithm
 	// should detect and stop it.
-	cache                Cache
+	cache Cache
 }
 
 // global limits
 type PrefetchGlobalState struct {
-	mutex                 sync.Mutex  // Lock used to control the files table
+	mutex                 sync.Mutex // Lock used to control the files table
 	verbose               bool
 	verboseLevel          int
 	handlesInfo           map[fuseops.HandleID](*PrefetchFileMetadata) // tracking state per handle
-	ioQueue               chan IoReq    // queue of IOs to prefetch
+	ioQueue               chan IoReq                                   // queue of IOs to prefetch
 	wg                    sync.WaitGroup
 	prefetchMaxIoSize     int64
 	numPrefetchThreads    int
@@ -157,10 +157,14 @@ func (iov Iovec) intersectBuffer(startOfs int64, endOfs int64) []byte {
 
 func (iov Iovec) stateString() string {
 	switch iov.state {
-	case IOV_HOLE: return "HOLE"
-	case IOV_IN_FLIGHT: return "IN_FLIGHT"
-	case IOV_DONE: return "DONE"
-	case IOV_ERRORED: return "ERRORED"
+	case IOV_HOLE:
+		return "HOLE"
+	case IOV_IN_FLIGHT:
+		return "IN_FLIGHT"
+	case IOV_DONE:
+		return "DONE"
+	case IOV_ERRORED:
+		return "ERRORED"
 	default:
 		panic(fmt.Sprintf("bad state for iovec %d", iov.state))
 	}
@@ -174,10 +178,14 @@ func (pfm *PrefetchFileMetadata) log(a string, args ...interface{}) {
 
 func (pfm *PrefetchFileMetadata) stateString() string {
 	switch pfm.state {
-	case PFM_NIL: return "NIL"
-	case PFM_DETECT_SEQ: return "DETECT_SEQ"
-	case PFM_PREFETCH_IN_PROGRESS: return "PREFETCHING"
-	case PFM_EOF: return "EOF"
+	case PFM_NIL:
+		return "NIL"
+	case PFM_DETECT_SEQ:
+		return "DETECT_SEQ"
+	case PFM_PREFETCH_IN_PROGRESS:
+		return "PREFETCHING"
+	case PFM_EOF:
+		return "EOF"
 	default:
 		panic(fmt.Sprintf("bad state for pfm %d", pfm.state))
 	}
@@ -223,7 +231,7 @@ func NewPrefetchGlobalState(verboseLevel int, dxEnv dxda.DXEnvironment) *Prefetc
 	// 2) not have more than two workers per CPU
 	// 3) not go over an overall limit, regardless of machine size
 	numCPUs := runtime.NumCPU()
-	numPrefetchThreads := MinInt(numCPUs * 2, maxNumPrefetchThreads)
+	numPrefetchThreads := MinInt(numCPUs*2, maxNumPrefetchThreads)
 	log.Printf("Number of prefetch threads=%d", numPrefetchThreads)
 
 	// The number of read-ahead should be limited to 8
@@ -252,18 +260,18 @@ func NewPrefetchGlobalState(verboseLevel int, dxEnv dxda.DXEnvironment) *Prefetc
 	totalMemoryBytes := 2 * maxNumEntriesInTable * prefetchMaxIoSize
 	totalMemoryBytes += int64(maxNumChunksReadAhead) * prefetchMaxIoSize
 
-	log.Printf("maximal memory usage: %dMiB", totalMemoryBytes / MiB)
+	log.Printf("maximal memory usage: %dMiB", totalMemoryBytes/MiB)
 	log.Printf("number of prefetch worker threads: %d", numPrefetchThreads)
 	log.Printf("maximal number of read-ahead chunks: %d", maxNumChunksReadAhead)
 
 	pgs := &PrefetchGlobalState{
-		verbose : verboseLevel >= 1,
-		verboseLevel : verboseLevel,
-		handlesInfo : make(map[fuseops.HandleID](*PrefetchFileMetadata)),
-		ioQueue : make(chan IoReq),
-		prefetchMaxIoSize : prefetchMaxIoSize,
-		numPrefetchThreads: numPrefetchThreads,
-		maxNumChunksReadAhead : maxNumChunksReadAhead,
+		verbose:               verboseLevel >= 1,
+		verboseLevel:          verboseLevel,
+		handlesInfo:           make(map[fuseops.HandleID](*PrefetchFileMetadata)),
+		ioQueue:               make(chan IoReq),
+		prefetchMaxIoSize:     prefetchMaxIoSize,
+		numPrefetchThreads:    numPrefetchThreads,
+		maxNumChunksReadAhead: maxNumChunksReadAhead,
 	}
 
 	// limit the number of prefetch IOs
@@ -406,20 +414,20 @@ func (pgs *PrefetchGlobalState) DownloadEntireFile(
 	endOfs := size - 1
 	startByte := int64(0)
 	for startByte <= endOfs {
-		endByte := MinInt64(startByte + pgs.prefetchMaxIoSize - 1, endOfs)
+		endByte := MinInt64(startByte+pgs.prefetchMaxIoSize-1, endOfs)
 		iovLen := endByte - startByte + 1
 
 		// read one chunk of the file
 		uniqueId := atomic.AddUint64(&pgs.ioCounter, 1)
 		ioReq := IoReq{
-			hid : 0, // Invalid handle, shouldn't be in a table
-			inode : inode,
-			size : size,
-			url : url,
-			ioSize : iovLen,
-			startByte : startByte,
-			endByte : endByte,
-			id : uniqueId,
+			hid:       0, // Invalid handle, shouldn't be in a table
+			inode:     inode,
+			size:      size,
+			url:       url,
+			ioSize:    iovLen,
+			startByte: startByte,
+			endByte:   endByte,
+			id:        uniqueId,
 		}
 
 		data, err := pgs.readData(client, ioReq)
@@ -480,7 +488,6 @@ func (pgs *PrefetchGlobalState) addIoReqToCache(pfm *PrefetchFileMetadata, ioReq
 	pfm.cache.iovecs[iovIdx].cond.Broadcast()
 }
 
-
 func (pgs *PrefetchGlobalState) getAndLockPfm(hid fuseops.HandleID) *PrefetchFileMetadata {
 	pgs.mutex.Lock()
 
@@ -533,7 +540,6 @@ func (pgs *PrefetchGlobalState) prefetchIoWorker() {
 		}
 	}
 }
-
 
 // Check if a file is worth tracking.
 func (pgs *PrefetchGlobalState) isWorthIt(pfm *PrefetchFileMetadata, now time.Time) bool {
@@ -592,20 +598,20 @@ func (pgs *PrefetchGlobalState) newPrefetchFileMetadata(
 	url DxDownloadURL) *PrefetchFileMetadata {
 	now := time.Now()
 	return &PrefetchFileMetadata{
-		mutex : sync.Mutex{},
-		hid : hid,
-		inode : f.Inode,
-		id : f.Id,
-		size : f.Size,
-		url : url,
-		state : PFM_NIL,  // Initial state of the file; no IOs were detected yet
-		lastIoTimestamp : now,
-		hiUserAccessOfs : 0,
-		mw : MeasureWindow{
-			timestamp : now,
-			numIOs : 0,
-			numBytesPrefetched : 0,
-			numPrefetchIOs : 0,
+		mutex:           sync.Mutex{},
+		hid:             hid,
+		inode:           f.Inode,
+		id:              f.Id,
+		size:            f.Size,
+		url:             url,
+		state:           PFM_NIL, // Initial state of the file; no IOs were detected yet
+		lastIoTimestamp: now,
+		hiUserAccessOfs: 0,
+		mw: MeasureWindow{
+			timestamp:          now,
+			numIOs:             0,
+			numBytesPrefetched: 0,
+			numPrefetchIOs:     0,
 		},
 	}
 }
@@ -623,29 +629,29 @@ func (pgs *PrefetchGlobalState) firstAccessToStream(pfm *PrefetchFileMetadata, o
 	startOfs := (ofs / pageSize) * pageSize
 
 	iov1 := &Iovec{
-		ioSize : prefetchMinIoSize,
-		startByte : startOfs,
-		endByte : startOfs + prefetchMinIoSize - 1,
-		touched : 0,
-		data : nil,
-		state : IOV_HOLE,
-		cond : sync.NewCond(&pfm.mutex),
+		ioSize:    prefetchMinIoSize,
+		startByte: startOfs,
+		endByte:   startOfs + prefetchMinIoSize - 1,
+		touched:   0,
+		data:      nil,
+		state:     IOV_HOLE,
+		cond:      sync.NewCond(&pfm.mutex),
 	}
 	iov2 := &Iovec{
-		ioSize : prefetchMinIoSize,
-		startByte : iov1.startByte + prefetchMinIoSize,
-		endByte : iov1.endByte + prefetchMinIoSize,
-		touched : 0,
-		data : nil,
-		state : IOV_HOLE,
-		cond : sync.NewCond(&pfm.mutex),
+		ioSize:    prefetchMinIoSize,
+		startByte: iov1.startByte + prefetchMinIoSize,
+		endByte:   iov1.endByte + prefetchMinIoSize,
+		touched:   0,
+		data:      nil,
+		state:     IOV_HOLE,
+		cond:      sync.NewCond(&pfm.mutex),
 	}
 	pfm.cache = Cache{
-		prefetchIoSize : prefetchMinIoSize,
-		maxNumIovecs : 2,
-		startByte : iov1.startByte,
-		endByte : iov2.endByte,
-		iovecs : make([]*Iovec, 2),
+		prefetchIoSize: prefetchMinIoSize,
+		maxNumIovecs:   2,
+		startByte:      iov1.startByte,
+		endByte:        iov2.endByte,
+		iovecs:         make([]*Iovec, 2),
 	}
 	pfm.cache.iovecs[0] = iov1
 	pfm.cache.iovecs[1] = iov2
@@ -707,7 +713,7 @@ func (pfm *PrefetchFileMetadata) markRangeInIovec(iovec *Iovec, startOfs int64, 
 	}
 	check(endSlot >= 0 && endSlot <= numSlotsInChunk)
 
-	for slot := startSlot; slot <= endSlot ; slot++ {
+	for slot := startSlot; slot <= endSlot; slot++ {
 		// Sets the bit at position [slot]
 		iovec.touched |= (1 << uint(slot))
 	}
@@ -755,7 +761,6 @@ func (pgs *PrefetchGlobalState) findCoveredRange(
 	return first, last
 }
 
-
 // Setup cache state for the next prefetch.
 //
 // 1) we want there to be several chunks ahead of us.
@@ -787,33 +792,33 @@ func (pgs *PrefetchGlobalState) moveCacheWindow(pfm *PrefetchFileMetadata, iovIn
 			if startByte > lastByteInFile {
 				break
 			}
-			endByte := MinInt64(startByte + int64(pfm.cache.prefetchIoSize) - 1, lastByteInFile)
+			endByte := MinInt64(startByte+int64(pfm.cache.prefetchIoSize)-1, lastByteInFile)
 			iov := &Iovec{
-				ioSize : endByte - startByte + 1,
-				startByte : startByte,
-				endByte : endByte,
-				touched : 0,
-				data : nil,
-				state : IOV_IN_FLIGHT,
-				cond : sync.NewCond(&pfm.mutex),
+				ioSize:    endByte - startByte + 1,
+				startByte: startByte,
+				endByte:   endByte,
+				touched:   0,
+				data:      nil,
+				state:     IOV_IN_FLIGHT,
+				cond:      sync.NewCond(&pfm.mutex),
 			}
 			uniqueId := atomic.AddUint64(&pgs.ioCounter, 1)
 			pgs.ioQueue <- IoReq{
-				hid : pfm.hid,
-				inode : pfm.inode,
-				size : pfm.size,
-				url : pfm.url,
-				ioSize : iov.ioSize,
-				startByte : iov.startByte,
-				endByte : iov.endByte,
-				id : uniqueId,
+				hid:       pfm.hid,
+				inode:     pfm.inode,
+				size:      pfm.size,
+				url:       pfm.url,
+				ioSize:    iov.ioSize,
+				startByte: iov.startByte,
+				endByte:   iov.endByte,
+				id:        uniqueId,
 			}
 			check(iov.ioSize <= pgs.prefetchMaxIoSize)
 			pfm.cache.iovecs = append(pfm.cache.iovecs, iov)
 
 			if pgs.verbose {
 				pfm.log("Adding chunk %d [%d -- %d]",
-					len(pfm.cache.iovecs) - 1,
+					len(pfm.cache.iovecs)-1,
 					iov.startByte,
 					iov.endByte)
 			}
@@ -835,7 +840,7 @@ func (pgs *PrefetchGlobalState) moveCacheWindow(pfm *PrefetchFileMetadata, iovIn
 			}
 		}
 		if nRemoved > 0 {
-			pfm.cache.iovecs = pfm.cache.iovecs[nRemoved : ]
+			pfm.cache.iovecs = pfm.cache.iovecs[nRemoved:]
 			if pgs.verbose {
 				pfm.log("Removed %d chunks", nRemoved)
 			}
@@ -857,7 +862,6 @@ func (pgs *PrefetchGlobalState) moveCacheWindow(pfm *PrefetchFileMetadata, iovIn
 	}
 }
 
-
 func (pgs *PrefetchGlobalState) markAccessedAndMaybeStartPrefetch(
 	pfm *PrefetchFileMetadata,
 	startOfs int64,
@@ -877,22 +881,23 @@ func (pgs *PrefetchGlobalState) markAccessedAndMaybeStartPrefetch(
 	numAccessed := bits.OnesCount64(currentIovec.touched)
 	if pgs.verboseLevel >= 2 {
 		pfm.log("touch: ofs=%d  len=%d  numAccessed=%d",
-			startOfs, endOfs - startOfs, numAccessed)
+			startOfs, endOfs-startOfs, numAccessed)
 	}
-	if numAccessed < numSlotsInChunk {
+	if numAccessed < (numSlotsInChunk - 32) {
 		return true
 	}
 	// A sufficient number of the slots were accessed. Start a prefetch for
 	// the next chunk(s)
 
 	if pfm.state == PFM_DETECT_SEQ {
+		pfm.log("set to pfm in progress")
 		pfm.state = PFM_PREFETCH_IN_PROGRESS
 	}
 
 	// increase io size, using a bounded exponential formula
 	if pfm.cache.prefetchIoSize < pgs.prefetchMaxIoSize {
 		pfm.cache.prefetchIoSize =
-			MinInt64(pgs.prefetchMaxIoSize, pfm.cache.prefetchIoSize * prefetchIoFactor)
+			MinInt64(pgs.prefetchMaxIoSize, pfm.cache.prefetchIoSize*prefetchIoFactor)
 	}
 	if pfm.cache.prefetchIoSize == pgs.prefetchMaxIoSize {
 		// Give each stream at least one read-ahead request. If there
@@ -908,13 +913,12 @@ func (pgs *PrefetchGlobalState) markAccessedAndMaybeStartPrefetch(
 		pgs.moveCacheWindow(pfm, last)
 
 		// Have we reached the end of the file?
-		if pfm.cache.endByte >= pfm.size - 1 {
+		if pfm.cache.endByte >= pfm.size-1 {
 			pfm.state = PFM_EOF
 		}
 	}
 	return true
 }
-
 
 const (
 	DATA_OUTSIDE_CACHE = 1 // data not in cache
@@ -925,11 +929,16 @@ const (
 
 func cacheCode2string(retCode int) string {
 	switch retCode {
-	case DATA_OUTSIDE_CACHE: return "OUTSIDE_CACHE"
-	case DATA_IN_CACHE: return "IN_CACHE"
-	case DATA_HOLE: return "HOLE"
-	case DATA_WAIT : return "WAIT"
-	default: panic(fmt.Sprintf("unknown cache code %d", retCode))
+	case DATA_OUTSIDE_CACHE:
+		return "OUTSIDE_CACHE"
+	case DATA_IN_CACHE:
+		return "IN_CACHE"
+	case DATA_HOLE:
+		return "HOLE"
+	case DATA_WAIT:
+		return "WAIT"
+	default:
+		panic(fmt.Sprintf("unknown cache code %d", retCode))
 	}
 }
 
@@ -972,20 +981,19 @@ func (pgs *PrefetchGlobalState) isDataInCache(
 	return DATA_IN_CACHE
 }
 
-
 // The IO is entirely in the cache, and all the data
 // is there.
 func (pgs *PrefetchGlobalState) copyDataFromCache(
 	pfm *PrefetchFileMetadata,
 	startOfs int64,
 	endOfs int64,
-	data  []byte) int {
+	data []byte) int {
 	first, last := pgs.findCoveredRange(pfm, startOfs, endOfs)
 	check(0 <= first && 0 <= last)
 	cursor := 0
 	for i := first; i <= last; i++ {
 		iov := pfm.cache.iovecs[i]
-		check (iov.state == IOV_DONE)
+		check(iov.state == IOV_DONE)
 		subBuf := iov.intersectBuffer(startOfs, endOfs)
 		len := copy(data[cursor:], subBuf)
 		cursor += len
@@ -1001,7 +1009,7 @@ func (pgs *PrefetchGlobalState) getDataFromCache(
 	pfm *PrefetchFileMetadata,
 	startOfs int64,
 	endOfs int64,
-	data  []byte) (int, int) {
+	data []byte) (int, int) {
 	numTries := 3
 	for i := 0; i < numTries; i++ {
 		retCode := pgs.isDataInCache(pfm, startOfs, endOfs)
@@ -1069,6 +1077,7 @@ func (pgs *PrefetchGlobalState) CacheLookup(hid fuseops.HandleID, startOfs int64
 		return 0
 
 	case PFM_PREFETCH_IN_PROGRESS:
+		pfm.log("pfm prefetch in progress")
 		// ongoing prefetch IO
 		pgs.markAccessedAndMaybeStartPrefetch(pfm, startOfs, endOfs)
 		retCode, len := pgs.getDataFromCache(pfm, startOfs, endOfs, data)
@@ -1081,9 +1090,13 @@ func (pgs *PrefetchGlobalState) CacheLookup(hid fuseops.HandleID, startOfs int64
 
 	case PFM_EOF:
 		// don't issue any more prefetch IOs, we have reached the end of the file
-		_, len := pgs.getDataFromCache(pfm, startOfs, endOfs, data)
+		retCode, len := pgs.getDataFromCache(pfm, startOfs, endOfs, data)
+		if retCode == DATA_OUTSIDE_CACHE {
+			// The file is being accessed again, perhaps reading from a different region
+			// reset the cache and start over
+			pgs.resetPfm(pfm)
+		}
 		return len
-
 	default:
 		log.Panicf("bad state %d for fileId=%s", pfm.state, pfm.id)
 		return 0

--- a/util.go
+++ b/util.go
@@ -29,7 +29,7 @@ const (
 	MaxDirSize                = 255 * 1000
 	MaxNumFileHandles         = 1000 * 1000
 	NumRetriesDefault         = 3
-	Version                   = "v0.22.4"
+	Version                   = "v0.23.0"
 )
 const (
 	InodeInvalid = 0

--- a/util.go
+++ b/util.go
@@ -26,7 +26,7 @@ const (
 	HttpClientPoolSize        = 4
 	FileWriteInactivityThresh = 5 * time.Minute
 	WritableFileSizeLimit     = 16 * MiB
-	MaxDirSize                = 10 * 1000
+	MaxDirSize                = 255 * 1000
 	MaxNumFileHandles         = 1000 * 1000
 	NumRetriesDefault         = 3
 	Version                   = "v0.22.4"


### PR DESCRIPTION
Raise directory limit from 10k --> 255k objects within a directory. TODO need to optimize the posix massaging.

Continue prefetching sequential data even if not all of the data in a previous IO range has not been read, required for `plink`. Reset prefetch state for a file if it has been read to the end and is being re-accessed. TODO more testing against typical applications. 

Bugfix where files were created as read-write even if dxfuse is running as read-only.

gofmt  