### PR TITLE
Bump dxda from v0.5.1 --> v0.5.4. Increment to v0.23.1 for release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dnanexus/dxfuse
 go 1.14
 
 require (
-	github.com/dnanexus/dxda v0.5.1
+	github.com/dnanexus/dxda v0.5.4
 	github.com/jacobsa/fuse v0.0.0-20200706075950-f8927095af03
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
-github.com/dnanexus/dxda v0.5.1 h1:bDzP08Q5v/TiHWjl+rixgvmecmgeY0NmpWgwo5l3Fio=
-github.com/dnanexus/dxda v0.5.1/go.mod h1:Nllx9MZtLqeTGA7crgn/MtU0j5XlZ6zb+akPgRdd1ag=
+github.com/dnanexus/dxda v0.5.4 h1:qSfi/eK01g/exWJIyYQ37r08yO3Cx7v+1J6MeQL+kxE=
+github.com/dnanexus/dxda v0.5.4/go.mod h1:Nllx9MZtLqeTGA7crgn/MtU0j5XlZ6zb+akPgRdd1ag=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/jacobsa/fuse v0.0.0-20200706075950-f8927095af03 h1:sRdTE2abfdMznz2TiNxKVgqAYsgtjRu7JOHvzVKs0mo=

--- a/util.go
+++ b/util.go
@@ -29,7 +29,7 @@ const (
 	MaxDirSize                = 255 * 1000
 	MaxNumFileHandles         = 1000 * 1000
 	NumRetriesDefault         = 3
-	Version                   = "v0.23.0"
+	Version                   = "v0.23.1"
 )
 const (
 	InodeInvalid = 0


### PR DESCRIPTION
Hopefully will fix a number of dxfuse crashes which look like the following to a user
```
Cannot read: Software caused connection abort
Cannot read: Transport endpoint is not connected
```
`DxHttpRequest()` fails and should be retried, but there was an invalid reference of `err` in logging https://github.com/dnanexus/dxda/blob/v0.5.1/dx_http.go#L298, fixed in dxda v0.5.2 with https://github.com/dnanexus/dxda/commit/2427521144b70391f628c7bef244eab518b11cdb
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x73d61a]

goroutine 11 [running]:
panic(0x91c7e0, 0xf30fe0)
	/usr/local/go/src/runtime/panic.go:1064 +0x46d fp=0xc0000ed850 sp=0xc0000ed798 pc=0x43f19d
runtime.panicmem(...)
	/usr/local/go/src/runtime/panic.go:212
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:695 +0x3da fp=0xc0000ed880 sp=0xc0000ed850 pc=0x4551da
github.com/dnanexus/dxda.DxHttpRequest(0xa50c00, 0xc000314d40, 0xc000097b90, 0x1, 0x995bc4, 0x3, 0xc000499030, 0x62, 0xc0000edaf8, 0xc000278630, ...)
	/home/kjensen/go/pkg/mod/github.com/dnanexus/dxda@v0.5.1/dx_http.go:298 +0x29a fp=0xc0000ed988 sp=0xc0000ed880 pc=0x73d61a
github.com/dnanexus/dxfuse.(*PrefetchGlobalState).readData(0xc00005c720, 0xc000097b90, 0x2, 0x1a, 0x270b8e00000, 0xc000499030, 0x62, 0xc000492420, 0x100000, 0x773f80000, ...)
	/home/kjensen/repos/dxfuse/prefetch.go:370 +0x664 fp=0xc0000eddb0 sp=0xc0000ed988 pc=0x7f54b4
github.com/dnanexus/dxfuse.(*PrefetchGlobalState).prefetchIoWorker(0xc00005c720)
	/home/kjensen/repos/dxfuse/prefetch.go:519 +0xf7 fp=0xc0000edfd8 sp=0xc0000eddb0 pc=0x7f66b7
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc0000edfe0 sp=0xc0000edfd8 pc=0x46eaa1
created by github.com/dnanexus/dxfuse.NewPrefetchGlobalState
	/home/kjensen/repos/dxfuse/prefetch.go:280 +0x2ec
```