### PR TITLE
DEVEX-1899 Increase wait for initialization to 90 seconds

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -173,7 +173,7 @@ func fsDaemon(
 }
 
 func waitForReady(logFile string) string {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 90; i++ {
 		time.Sleep(1 * time.Second)
 
 		// read the log file and look for either "ready" or "error"


### PR DESCRIPTION
Occasionally under slow I/O or heavy I/O conditions, dxfuse requires more time to initialize. 