### PR TITLE
Manifest filename will now be created per user

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -434,7 +434,7 @@ func startDaemonAndWaitForInitializationToComplete(cfg Config, logFile string) {
 		os.Exit(1)
 	}
 
-	username := getUser().username
+	username := getUser().Username
 	fullManifestPath := fmt.Printf("/tmp/%s_dxfuse_manifest.json", username)
 	err = ioutil.WriteFile(fullManifestPath, manifestJSON, 0644)
 	if err != nil {

--- a/cli/main.go
+++ b/cli/main.go
@@ -434,8 +434,8 @@ func startDaemonAndWaitForInitializationToComplete(cfg Config, logFile string) {
 		os.Exit(1)
 	}
 
-	// This could be converted into a random temporary file to avoid collisions
-	fullManifestPath := "/tmp/dxfuse_manifest.json"
+	username := getUser().username
+	fullManifestPath := fmt.Printf("/tmp/%s_dxfuse_manifest.json", username)
 	err = ioutil.WriteFile(fullManifestPath, manifestJSON, 0644)
 	if err != nil {
 		fmt.Printf("Error writing out fully elaborated manifest to %s (%s)",

--- a/cli/main.go
+++ b/cli/main.go
@@ -435,7 +435,7 @@ func startDaemonAndWaitForInitializationToComplete(cfg Config, logFile string) {
 	}
 
 	username := getUser().Username
-	fullManifestPath := fmt.Printf("/tmp/%s_dxfuse_manifest.json", username)
+	fullManifestPath := fmt.Sprintf("/tmp/%s_dxfuse_manifest.json", username)
 	err = ioutil.WriteFile(fullManifestPath, manifestJSON, 0644)
 	if err != nil {
 		fmt.Printf("Error writing out fully elaborated manifest to %s (%s)",


### PR DESCRIPTION
The manifest will now be created per user in /tmp, which allows the parallel use of dxfuse with multiple users logged in.