### PR TITLE
DEVEX-2123 Fix crash when file-xxxx/download returns an error

### DIFF
--- a/dxfuse.go
+++ b/dxfuse.go
@@ -1295,7 +1295,7 @@ func (fsys *Filesys) openRegularFile(
 	body, err := dxda.DxAPI(ctx, oph.httpClient, NumRetriesDefault, &fsys.dxEnv, fmt.Sprintf("%s/download", f.Id), payload)
 	if err != nil {
 		oph.RecordError(err)
-		return nil, err
+		return nil, fsys.translateError(err)
 	}
 	var u DxDownloadURL
 	json.Unmarshal(body, &u)

--- a/util.go
+++ b/util.go
@@ -30,7 +30,7 @@ const (
 	NumRetriesDefault         = 10
 	InitialUploadPartSize     = 16 * MiB
 	MaxUploadPartSize         = 700 * MiB
-	Version                   = "v1.0.0"
+	Version                   = "v1.0.1"
 )
 const (
 	InodeInvalid = 0


### PR DESCRIPTION
Fix crash when `file-xxxx/download` returns an error in `OpenFileOp`. 

Bump version to `v1.0.1` for release.