### PR TITLE
DEVEX-2135 Write temporary manifest to `$HOME/.dxfuse/`

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -435,7 +435,8 @@ func startDaemonAndWaitForInitializationToComplete(cfg Config, logFile string) {
 	}
 
 	// This could be converted into a random temporary file to avoid collisions
-	fullManifestPath := "/tmp/dxfuse_manifest.json"
+
+	fullManifestPath := filepath.Join(dxfuse.MakeFSBaseDir(), "dxfuse_manifest.json")
 	err = ioutil.WriteFile(fullManifestPath, manifestJSON, 0644)
 	if err != nil {
 		fmt.Printf("Error writing out fully elaborated manifest to %s (%s)",
@@ -490,7 +491,7 @@ func main() {
 	flag.Parse()
 	cfg := parseCmdLineArgs()
 	validateConfig(cfg)
-	logFile := dxfuse.MakeFSBaseDir() + "/" + dxfuse.LogFile
+	logFile := filepath.Join(dxfuse.MakeFSBaseDir(), dxfuse.LogFile)
 	fmt.Printf("The log file is located at %s\n", logFile)
 
 	dxda.UserAgent = fmt.Sprintf("dxfuse/%s (%s)", dxfuse.Version, runtime.GOOS)

--- a/util.go
+++ b/util.go
@@ -30,7 +30,7 @@ const (
 	NumRetriesDefault         = 10
 	InitialUploadPartSize     = 16 * MiB
 	MaxUploadPartSize         = 700 * MiB
-	Version                   = "v1.0.1"
+	Version                   = "v1.1.0"
 )
 const (
 	InodeInvalid = 0


### PR DESCRIPTION
Write temporary manifest to `$HOME/.dxfuse/` instead of `/tmp/` to allow multiple users to concurrently run dxfuse on the same system.

Bump version to `v1.1.0` for release. 