### PR TITLE
DEVEX-2143 Comment out unused command server

### DIFF
--- a/dxfuse.go
+++ b/dxfuse.go
@@ -65,7 +65,7 @@ type Filesys struct {
 	ops *DxOps
 
 	// A way to send external commands to the filesystem
-	cmdSrv *CmdServer
+	// cmdSrv *CmdServer
 
 	// description for each mounted project
 	projId2Desc map[string]DxDescribePrj
@@ -220,8 +220,8 @@ func NewDxfuse(
 	//fsys.sybx = NewSyncDbDx(options, dxEnv, projId2Desc, mdb, fsys.mutex)
 
 	// create an endpoint for communicating with the user
-	fsys.cmdSrv = NewCmdServer(options, fsys.sybx)
-	fsys.cmdSrv.Init()
+	// fsys.cmdSrv = NewCmdServer(options, fsys.sybx)
+	// fsys.cmdSrv.Init()
 
 	return fsys, nil
 }
@@ -256,7 +256,7 @@ func (fsys *Filesys) Shutdown() {
 	fsys.pgs.Shutdown()
 
 	// close the command server, this frees up the port
-	fsys.cmdSrv.Close()
+	// fsys.cmdSrv.Close()
 
 	if fsys.uploader != nil {
 		fsys.uploader.Shutdown()

--- a/dxfuse.go
+++ b/dxfuse.go
@@ -219,6 +219,7 @@ func NewDxfuse(
 	// initialize sync daemon
 	//fsys.sybx = NewSyncDbDx(options, dxEnv, projId2Desc, mdb, fsys.mutex)
 
+	// DEVEX-2143 removed for now, could be useful again in the future for other enhancements
 	// create an endpoint for communicating with the user
 	// fsys.cmdSrv = NewCmdServer(options, fsys.sybx)
 	// fsys.cmdSrv.Init()

--- a/util.go
+++ b/util.go
@@ -30,7 +30,7 @@ const (
 	NumRetriesDefault         = 10
 	InitialUploadPartSize     = 16 * MiB
 	MaxUploadPartSize         = 700 * MiB
-	Version                   = "v1.1.0"
+	Version                   = "v1.1.1"
 )
 const (
 	InodeInvalid = 0


### PR DESCRIPTION
The server previously used for listening to `dxfuse -sync` commands in now unused. Remove it for now. 

Fixes https://github.com/dnanexus/dxfuse/issues/78