### PR TITLE
DEVEX-2278 Fix symlink files

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,7 @@ jobs:
           python3 python3-pip python3-dev
 
           # Install printing with colors python package
-          python3 -m pip install setuptools wheel pyOpenSSL
+          python3 -m pip install --upgrade setuptools wheel pyOpenSSL
           wget https://raw.githubusercontent.com/dnanexus/dx-toolkit/master/src/python/requirements.txt
           python3 -m pip install -r requirements.txt
 
@@ -75,7 +75,7 @@ jobs:
           openssl libssl-dev zip unzip libffi-dev \
           python3 python3-pip python3-dev
           # Install printing with colors python package
-          python3 -m pip install setuptools wheel pyOpenSSL
+          python3 -m pip install --upgrade setuptools wheel pyOpenSSL
           wget https://raw.githubusercontent.com/dnanexus/dx-toolkit/master/src/python/requirements.txt
           python3 -m pip install -r requirements.txt
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,7 @@ jobs:
           python3 python3-pip python3-dev
 
           # Install printing with colors python package
-          python3 -m pip install setuptools wheel
+          python3 -m pip install setuptools wheel pyOpenSSL
           wget https://raw.githubusercontent.com/dnanexus/dx-toolkit/master/src/python/requirements.txt
           python3 -m pip install -r requirements.txt
 
@@ -75,7 +75,7 @@ jobs:
           openssl libssl-dev zip unzip libffi-dev \
           python3 python3-pip python3-dev
           # Install printing with colors python package
-          python3 -m pip install setuptools wheel
+          python3 -m pip install setuptools wheel pyOpenSSL
           wget https://raw.githubusercontent.com/dnanexus/dx-toolkit/master/src/python/requirements.txt
           python3 -m pip install -r requirements.txt
 

--- a/doc/Internals.md
+++ b/doc/Internals.md
@@ -19,7 +19,6 @@ The `data_objects` table maintains information for files, applets, workflows, an
 | mode            | int      | Unix permission bits |
 | tags            | text     | DNAx tags for this object, encoded as a JSON array |
 | properties      | text     | DNAx properties for this object, encoded as JSON  |
-| symlink         | text     | holds the path for a symlink (if symlink) |
 | local\_path     | text     | if file has a local copy, this is the path |
 | dirty\_data     | int      | has the data been modified? (only files) |
 | dirty\_metadata | int      | have the tags or properties been modified? |

--- a/dx_describe.go
+++ b/dx_describe.go
@@ -31,7 +31,6 @@ type DxDescribeDataObject struct {
 	MtimeSeconds  int64
 	Tags          []string
 	Properties    map[string]string
-	SymlinkPath   string
 }
 
 // https://documentation.dnanexus.com/developer/api/data-containers/projects#api-method-project-xxxx-describe
@@ -83,10 +82,6 @@ type DxDescribeRawTop struct {
 	Describe DxDescribeRaw `json:"describe"`
 }
 
-type DxSymLink struct {
-	Url string `json:"object"`
-}
-
 type DxDescribeRaw struct {
 	Id               string            `json:"id"`
 	ProjId           string            `json:"project"`
@@ -99,7 +94,6 @@ type DxDescribeRaw struct {
 	Size             int64             `json:"size"`
 	Tags             []string          `json:"tags"`
 	Properties       map[string]string `json:"properties"`
-	SymlinkPath      *DxSymLink        `json:"symlinkPath,omitempty"`
 }
 
 // Describe a large number of file-ids in one API call.
@@ -126,8 +120,6 @@ func submit(
 			"size":          true,
 			"tags":          true,
 			"properties":    true,
-			"symlinkPath":   true,
-			"drive":         true,
 		},
 	}
 
@@ -175,11 +167,6 @@ func submit(
 	for _, descRawTop := range reply.Results {
 		descRaw := descRawTop.Describe
 
-		symlinkUrl := ""
-		if descRaw.SymlinkPath != nil {
-			symlinkUrl = descRaw.SymlinkPath.Url
-		}
-
 		desc := DxDescribeDataObject{
 			Id:            descRaw.Id,
 			ProjId:        descRaw.ProjId,
@@ -192,7 +179,6 @@ func submit(
 			MtimeSeconds:  descRaw.ModifiedMillisec / 1000,
 			Tags:          descRaw.Tags,
 			Properties:    descRaw.Properties,
-			SymlinkPath:   symlinkUrl,
 		}
 		//fmt.Printf("%v\n", desc)
 		files[desc.Id] = desc

--- a/dxfuse.go
+++ b/dxfuse.go
@@ -1141,8 +1141,6 @@ func (fsys *Filesys) readEntireDir(ctx context.Context, oph *OpHandle, dir Dir) 
 		switch oDesc.Kind {
 		case FK_Regular:
 			dType = fuseutil.DT_File
-		case FK_Symlink:
-			dType = fuseutil.DT_File
 		default:
 			// There is no good way to represent these
 			// in the filesystem.
@@ -1370,27 +1368,6 @@ func (fsys *Filesys) OpenFile(ctx context.Context, op *fuseops.OpenFileOp) error
 		fh, err = fsys.openRegularFile(ctx, oph, op, file)
 		if err != nil {
 			return err
-		}
-	case FK_Symlink:
-		// A symbolic link can use the remote URL address
-		// directly. There is no need to generate a preauthenticated
-		// URL.
-		tgid, _ := GetTgid(op.OpContext.Pid)
-		fh = &FileHandle{
-			accessMode: AM_RO_Remote,
-			inode:      file.Inode,
-			size:       file.Size,
-			Id:         file.Id,
-			url: &DxDownloadURL{
-				URL:     file.Symlink,
-				Headers: nil,
-			},
-			Tgid:              tgid,
-			lastPartId:        0,
-			nextWriteOffset:   0,
-			writeBuffer:       nil,
-			writeBufferOffset: 0,
-			mutex:             nil,
 		}
 	default:
 		// can't open an applet/workflow/etc.

--- a/util.go
+++ b/util.go
@@ -30,7 +30,7 @@ const (
 	NumRetriesDefault         = 10
 	InitialUploadPartSize     = 16 * MiB
 	MaxUploadPartSize         = 700 * MiB
-	Version                   = "v1.1.1"
+	Version                   = "v1.2.0"
 )
 const (
 	InodeInvalid = 0

--- a/util.go
+++ b/util.go
@@ -120,7 +120,6 @@ func (d Dir) GetInode() fuseops.InodeID {
 // Kinds of files
 const (
 	FK_Regular  = 10
-	FK_Symlink  = 11
 	FK_Applet   = 12
 	FK_Workflow = 13
 	FK_Record   = 14
@@ -158,9 +157,6 @@ type File struct {
 	// tags and properties
 	Tags       []string
 	Properties map[string]string
-
-	// for a symlink, it holds the path.
-	Symlink string
 
 	// is the file modified
 	dirtyData     bool


### PR DESCRIPTION
For the dxfuse client symlinks can be treated the same as regular file objects. The current support only works for symlinks backed by a publicly accessible object in cloud storage. 