### PR TITLE
COMPUTE-15 Revert `/listFolder` changes for v1.4.0 release

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -104,7 +104,7 @@ func getUser() user.User {
 }
 
 // Mount the filesystem:
-//  - setup the debug log to the FUSE kernel log (I think)
+//   - setup the debug log to the FUSE kernel log (I think)
 func fsDaemon(
 	mountpoint string,
 	dxEnv dxda.DXEnvironment,
@@ -419,7 +419,6 @@ func buildDaemonCommandLine(cfg Config, fullManifestPath string) []string {
 }
 
 // We are in the parent process.
-//
 func startDaemonAndWaitForInitializationToComplete(cfg Config, logFile string) {
 	manifest, err := parseManifest(cfg)
 	if err != nil {

--- a/cmd_client.go
+++ b/cmd_client.go
@@ -10,7 +10,6 @@ type CmdClient struct {
 }
 
 // Sending commands with a client
-//
 func NewCmdClient() *CmdClient {
 	return &CmdClient{}
 }

--- a/dx_ops.go
+++ b/dx_ops.go
@@ -357,9 +357,9 @@ type ReplyRename struct {
 	Id string `json:"id"`
 }
 
-//  API method: /class-xxxx/rename
+// API method: /class-xxxx/rename
 //
-//  rename a data object
+// rename a data object
 func (ops *DxOps) DxRename(
 	ctx context.Context,
 	httpClient *http.Client,
@@ -404,7 +404,7 @@ type ReplyMove struct {
 	Id string `json:"id"`
 }
 
-//  API method: /class-xxxx/move
+//	API method: /class-xxxx/move
 //
 // Moves the specified data objects and folders to a destination folder in the same container.
 func (ops *DxOps) DxMove(

--- a/manifest.go
+++ b/manifest.go
@@ -198,8 +198,9 @@ func MakeManifestFromProjectIds(
 
 // return all the parents of a directory.
 // For example:
-//   "/A/B/C"      ["/", "/A", "/A/B"]
-//   "/foo/bar"   ["/", "/foo"]
+//
+//	"/A/B/C"      ["/", "/A", "/A/B"]
+//	"/foo/bar"   ["/", "/foo"]
 func ancestors(p string) []string {
 	if p == "" || p == "/" {
 		return []string{"/"}
@@ -233,9 +234,12 @@ func (d Dirs) Less(i, j int) bool {
 
 // Figure out the directory structure needed to support
 // the leaf nodes. For example, if we need to create:
-//     ["/A/B/C", "/D", "/D/E"]
+//
+//	["/A/B/C", "/D", "/D/E"]
+//
 // then the skeleton is:
-//     ["/A", "/A/B", "/D"]
+//
+//	["/A", "/A/B", "/D"]
 //
 // The root directory is not reported in the skeleton.
 func (m *Manifest) DirSkeleton() ([]string, error) {

--- a/metadata_db.go
+++ b/metadata_db.go
@@ -102,8 +102,8 @@ func (mdb *MetadataDb) opClose(oph *OpHandle) {
 
 // Split a path into a parent and child. For example:
 //
-//   /A/B/C  -> "/A/B", "C"
-//   / ->       "", "/"
+//	/A/B/C  -> "/A/B", "C"
+//	/ ->       "", "/"
 func splitPath(fullPath string) (parentDir string, basename string) {
 	if fullPath == "/" {
 		// The anomalous case.
@@ -497,7 +497,6 @@ func (mdb *MetadataDb) lookupDirByInode(oph *OpHandle, parent string, dname stri
 }
 
 // search for a file with a particular inode.
-//
 func (mdb *MetadataDb) LookupByInode(ctx context.Context, oph *OpHandle, inode int64) (Node, bool, error) {
 	// point lookup in the namespace table
 	sqlStmt := fmt.Sprintf(`
@@ -554,7 +553,6 @@ func (mdb *MetadataDb) LookupDirByInode(ctx context.Context, oph *OpHandle, inod
 }
 
 // Find information on a directory by searching on its full name.
-//
 func (mdb *MetadataDb) lookupDirByName(oph *OpHandle, dirname string) (string, string, error) {
 	parentDir, basename := splitPath(dirname)
 	if mdb.options.Verbose {
@@ -700,10 +698,10 @@ func (mdb *MetadataDb) directoryReadAllEntries(
 
 // Create an entry representing one remote file. This has
 // several use cases:
-//  1) Create a singleton file from the manifest
-//  2) Create a new file, and upload it later to the platform
+//  1. Create a singleton file from the manifest
+//  2. Create a new file, and upload it later to the platform
 //     (the file-id will be the empty string "")
-//  3) Discover a file in a directory, which may actually be a link to another file.
+//  3. Discover a file in a directory, which may actually be a link to another file.
 func (mdb *MetadataDb) createDataObject(
 	oph *OpHandle,
 	kind int,
@@ -1398,9 +1396,9 @@ func (mdb *MetadataDb) UpdateFileLocalPath(
 }
 
 // Move a file
-// 1) Can move a file from one directory to another,
-//    or leave it in the same directory
-// 2) Can change the filename.
+//  1. Can move a file from one directory to another,
+//     or leave it in the same directory
+//  2. Can change the filename.
 func (mdb *MetadataDb) MoveFile(
 	ctx context.Context,
 	oph *OpHandle,
@@ -1488,7 +1486,6 @@ func (mdb *MetadataDb) execModifyRecord(oph *OpHandle, r MoveRecord) error {
 //
 // From the shell we issue the command:
 // $ mv A D/K/
-//
 func (mdb *MetadataDb) MoveDir(
 	ctx context.Context,
 	oph *OpHandle,

--- a/metadata_db.go
+++ b/metadata_db.go
@@ -102,8 +102,8 @@ func (mdb *MetadataDb) opClose(oph *OpHandle) {
 
 // Split a path into a parent and child. For example:
 //
-//	/A/B/C  -> "/A/B", "C"
-//	/ ->       "", "/"
+//   /A/B/C  -> "/A/B", "C"
+//   / ->       "", "/"
 func splitPath(fullPath string) (parentDir string, basename string) {
 	if fullPath == "/" {
 		// The anomalous case.
@@ -497,6 +497,7 @@ func (mdb *MetadataDb) lookupDirByInode(oph *OpHandle, parent string, dname stri
 }
 
 // search for a file with a particular inode.
+//
 func (mdb *MetadataDb) LookupByInode(ctx context.Context, oph *OpHandle, inode int64) (Node, bool, error) {
 	// point lookup in the namespace table
 	sqlStmt := fmt.Sprintf(`
@@ -553,6 +554,7 @@ func (mdb *MetadataDb) LookupDirByInode(ctx context.Context, oph *OpHandle, inod
 }
 
 // Find information on a directory by searching on its full name.
+//
 func (mdb *MetadataDb) lookupDirByName(oph *OpHandle, dirname string) (string, string, error) {
 	parentDir, basename := splitPath(dirname)
 	if mdb.options.Verbose {
@@ -698,10 +700,10 @@ func (mdb *MetadataDb) directoryReadAllEntries(
 
 // Create an entry representing one remote file. This has
 // several use cases:
-//  1. Create a singleton file from the manifest
-//  2. Create a new file, and upload it later to the platform
+//  1) Create a singleton file from the manifest
+//  2) Create a new file, and upload it later to the platform
 //     (the file-id will be the empty string "")
-//  3. Discover a file in a directory, which may actually be a link to another file.
+//  3) Discover a file in a directory, which may actually be a link to another file.
 func (mdb *MetadataDb) createDataObject(
 	oph *OpHandle,
 	kind int,
@@ -973,7 +975,7 @@ func (mdb *MetadataDb) directoryReadFromDNAx(
 	}
 
 	// describe all (closed) files
-	dxDir, err := DxDescribeFolder(ctx, oph.httpClient, &mdb.options, &mdb.dxEnv, projId, projFolder)
+	dxDir, err := DxDescribeFolder(ctx, oph.httpClient, &mdb.dxEnv, projId, projFolder)
 	if err != nil {
 		fmt.Printf(err.Error())
 		fmt.Printf("reading directory frmo DNAx error")
@@ -1396,9 +1398,9 @@ func (mdb *MetadataDb) UpdateFileLocalPath(
 }
 
 // Move a file
-//  1. Can move a file from one directory to another,
-//     or leave it in the same directory
-//  2. Can change the filename.
+// 1) Can move a file from one directory to another,
+//    or leave it in the same directory
+// 2) Can change the filename.
 func (mdb *MetadataDb) MoveFile(
 	ctx context.Context,
 	oph *OpHandle,
@@ -1486,6 +1488,7 @@ func (mdb *MetadataDb) execModifyRecord(oph *OpHandle, r MoveRecord) error {
 //
 // From the shell we issue the command:
 // $ mv A D/K/
+//
 func (mdb *MetadataDb) MoveDir(
 	ctx context.Context,
 	oph *OpHandle,

--- a/nonce.go
+++ b/nonce.go
@@ -34,7 +34,6 @@ func NewNonce() *Nonce {
 }
 
 // Create a random nonce, no longer than 128 bytes
-//
 func (n *Nonce) String() string {
 	b := make([]byte, nonceLen)
 

--- a/posix.go
+++ b/posix.go
@@ -10,27 +10,26 @@ import (
 
 // Try to fix a DNAx directory, so it will adhere to POSIX.
 //
-// 1. If several files share the same name, make them unique by moving into an
-//    extra subdirectory. For example:
+//  1. If several files share the same name, make them unique by moving into an
+//     extra subdirectory. For example:
 //
-//    src name file-id      new name
-//    X.txt    file-0001    X.txt
-//    X.txt    file-0005    1/X.txt
-//    X.txt    file-0012    2/X.txt
+//     src name file-id      new name
+//     X.txt    file-0001    X.txt
+//     X.txt    file-0005    1/X.txt
+//     X.txt    file-0012    2/X.txt
 //
 // 2. DNAx files can include slashes. Drop these files, with a put note in the log.
 //
-// 3. A directory and a file can have the same name. For example:
-//    ROOT/
-//         zoo/      sub-directory
-//         zoo       regular file
+//  3. A directory and a file can have the same name. For example:
+//     ROOT/
+//     zoo/      sub-directory
+//     zoo       regular file
 //
-//    Is converted into:
-//    ROOT
-//         zoo/      sub-directory
-//         1/        faux sub-directory
-//           zoo     regular file
-//
+//     Is converted into:
+//     ROOT
+//     zoo/      sub-directory
+//     1/        faux sub-directory
+//     zoo     regular file
 type PosixDir struct {
 	path        string // entire directory path
 	dataObjects []DxDescribeDataObject
@@ -103,7 +102,6 @@ func (px *Posix) pickFauxDirNames(subdirs []string, uniqueFileNames []string, nu
 }
 
 // Find all the unique file names.
-//
 func (px *Posix) uniqueFileNames(dxObjs []DxDescribeDataObject) []string {
 	usedNames := make(map[string]bool)
 

--- a/test/local/mm.go
+++ b/test/local/mm.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"golang.org/x/exp/mmap"
 	"flag"
 	"fmt"
+	"golang.org/x/exp/mmap"
 	"os"
 	"path/filepath"
 )
 
 type Config struct {
 	filename string
-	verbose bool
+	verbose  bool
 }
 
 var progName = filepath.Base(os.Args[0])
@@ -22,10 +22,9 @@ func usage() {
 }
 
 var (
-	help = flag.Bool("help", false, "display program options")
+	help    = flag.Bool("help", false, "display program options")
 	verbose = flag.Bool("verbose", false, "Enable verbose debugging")
 )
-
 
 func parseCmdLineArgs() Config {
 	if *help {
@@ -40,8 +39,8 @@ func parseCmdLineArgs() Config {
 	}
 
 	return Config{
-		filename : flag.Arg(0),
-		verbose : *verbose,
+		filename: flag.Arg(0),
+		verbose:  *verbose,
 	}
 }
 

--- a/util.go
+++ b/util.go
@@ -194,7 +194,6 @@ type DeadFile struct {
 //
 // Not that not only files have attributes, applets and workflows
 // have them too.
-//
 type DirtyFileInfo struct {
 	Inode         int64
 	dirtyData     bool
@@ -273,7 +272,6 @@ func LogMsg(moduleName string, a string, args ...interface{}) {
 	log.Printf("%s %s: %s", Time2string(now), moduleName, msg)
 }
 
-//
 // 1024   => 1KB
 // 10240  => 10KB
 // 1100000 => 1MB

--- a/util.go
+++ b/util.go
@@ -30,7 +30,7 @@ const (
 	NumRetriesDefault         = 10
 	InitialUploadPartSize     = 16 * MiB
 	MaxUploadPartSize         = 700 * MiB
-	Version                   = "v1.3.0"
+	Version                   = "v1.2.0"
 )
 const (
 	InodeInvalid = 0
@@ -194,6 +194,7 @@ type DeadFile struct {
 //
 // Not that not only files have attributes, applets and workflows
 // have them too.
+//
 type DirtyFileInfo struct {
 	Inode         int64
 	dirtyData     bool
@@ -272,6 +273,7 @@ func LogMsg(moduleName string, a string, args ...interface{}) {
 	log.Printf("%s %s: %s", Time2string(now), moduleName, msg)
 }
 
+//
 // 1024   => 1KB
 // 10240  => 10KB
 // 1100000 => 1MB

--- a/util.go
+++ b/util.go
@@ -30,7 +30,7 @@ const (
 	NumRetriesDefault         = 10
 	InitialUploadPartSize     = 16 * MiB
 	MaxUploadPartSize         = 700 * MiB
-	Version                   = "v1.2.0"
+	Version                   = "v1.4.0"
 )
 const (
 	InodeInvalid = 0


### PR DESCRIPTION
Revert https://github.com/dnanexus/dxfuse/commit/e3f92d86400244583c48302a47ae25e99f251d99 released in v1.30. API does not handle this any better than `/system/findDataObjects`. 

Bump version to v1.4.0 for release and gofmt.  