### PR TITLE
DEVEX-2466 Fix prefetch where read offset is before cache

### DIFF
--- a/dxfuse.go
+++ b/dxfuse.go
@@ -1413,7 +1413,7 @@ func (fsys *Filesys) readRemoteFile(ctx context.Context, op *fuseops.ReadFileOp,
 	len := fsys.pgs.CacheLookup(fh.hid, op.Offset, endOfs, op.Dst)
 	// log received length if less than requested
 	if fsys.options.Verbose && int64(len) < reqSize {
-		fsys.log("ReadFile: CacheLookup returned %d, requested %d", len, reqSize)
+		fsys.log("ReadFile: CacheLookup returned %d, requested %d, offset %d", len, reqSize, op.Offset)
 	}
 	if len > 0 {
 		op.BytesRead = len

--- a/prefetch.go
+++ b/prefetch.go
@@ -725,6 +725,18 @@ func (pgs *PrefetchGlobalState) findCoveredRange(
 	startOfs int64,
 	endOfs int64) (int, int) {
 
+	if startOfs < pfm.cache.startByte {
+		pfm.log("findCoverRange first < 0: startOfs=%d  endOfs=%d  cache=[%d -- %d]",
+			startOfs, endOfs, pfm.cache.startByte, pfm.cache.endByte)
+		// log all iovecs
+		for k, iovec := range pfm.cache.iovecs {
+			pfm.log("cache %d -> [%d -- %d]  %s", k, iovec.startByte, iovec.endByte,
+				iovec.stateString())
+		}
+		// The IO starts before the cache
+		return -1, -1
+	}
+
 	// check if there is ANY intersection with cache
 	if endOfs < pfm.cache.startByte ||
 		pfm.cache.endByte < startOfs {

--- a/prefetch.go
+++ b/prefetch.go
@@ -747,7 +747,6 @@ func (pgs *PrefetchGlobalState) findCoveredRange(
 				iovec.stateString())
 		}
 	}
-	check(first >= 0)
 
 	last := -1
 	for k, iovec := range pfm.cache.iovecs {

--- a/prefetch.go
+++ b/prefetch.go
@@ -231,7 +231,7 @@ func NewPrefetchGlobalState(verboseLevel int, dxEnv dxda.DXEnvironment) *Prefetc
 	// 2) not have more than two workers per CPU
 	// 3) not go over an overall limit, regardless of machine size
 	numCPUs := runtime.NumCPU()
-	numPrefetchThreads := MinInt(numCPUs*8, maxNumPrefetchThreads)
+	numPrefetchThreads := MinInt(numCPUs*2, maxNumPrefetchThreads)
 	log.Printf("Number of prefetch threads=%d", numPrefetchThreads)
 
 	// The number of read-ahead should be limited to 8

--- a/prefetch.go
+++ b/prefetch.go
@@ -725,18 +725,6 @@ func (pgs *PrefetchGlobalState) findCoveredRange(
 	startOfs int64,
 	endOfs int64) (int, int) {
 
-	if startOfs < pfm.cache.startByte {
-		pfm.log("findCoverRange first < 0: startOfs=%d  endOfs=%d  cache=[%d -- %d]",
-			startOfs, endOfs, pfm.cache.startByte, pfm.cache.endByte)
-		// log all iovecs
-		for k, iovec := range pfm.cache.iovecs {
-			pfm.log("cache %d -> [%d -- %d]  %s", k, iovec.startByte, iovec.endByte,
-				iovec.stateString())
-		}
-		// The IO starts before the cache
-		return -1, -1
-	}
-
 	// check if there is ANY intersection with cache
 	if endOfs < pfm.cache.startByte ||
 		pfm.cache.endByte < startOfs {
@@ -751,12 +739,9 @@ func (pgs *PrefetchGlobalState) findCoveredRange(
 			break
 		}
 	}
-	// if first < 0, log message
 	if first < 0 {
-		// log pfm.cache
 		pfm.log("findCoverRange first < 0: startOfs=%d  endOfs=%d  cache=[%d -- %d]",
 			startOfs, endOfs, pfm.cache.startByte, pfm.cache.endByte)
-		// log all iovecs
 		for k, iovec := range pfm.cache.iovecs {
 			pfm.log("cache %d -> [%d -- %d]  %s", k, iovec.startByte, iovec.endByte,
 				iovec.stateString())

--- a/prefetch.go
+++ b/prefetch.go
@@ -739,14 +739,6 @@ func (pgs *PrefetchGlobalState) findCoveredRange(
 			break
 		}
 	}
-	if first < 0 {
-		pfm.log("findCoverRange first < 0: startOfs=%d  endOfs=%d  cache=[%d -- %d]",
-			startOfs, endOfs, pfm.cache.startByte, pfm.cache.endByte)
-		for k, iovec := range pfm.cache.iovecs {
-			pfm.log("cache %d -> [%d -- %d]  %s", k, iovec.startByte, iovec.endByte,
-				iovec.stateString())
-		}
-	}
 
 	last := -1
 	for k, iovec := range pfm.cache.iovecs {

--- a/util.go
+++ b/util.go
@@ -30,7 +30,7 @@ const (
 	NumRetriesDefault         = 10
 	InitialUploadPartSize     = 16 * MiB
 	MaxUploadPartSize         = 700 * MiB
-	Version                   = "v1.4.0"
+	Version                   = "v1.4.1"
 )
 const (
 	InodeInvalid = 0


### PR DESCRIPTION
Remove `check(first >= 0)`, as `first < 0` is valid return value as -1 indicates `DATA_OUTSIDE_CACHE` handled in the calling function https://github.com/dnanexus/dxfuse/blob/DEVEX-2466/prefetch.go#L952-L957. 