### PR TITLE
COMPUTE-1242 Add `-stateFolder` arg for specifying dxfuse folder

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -374,9 +374,6 @@ func parseManifest(cfg Config) (*dxfuse.Manifest, error) {
 }
 
 func startDaemon(cfg Config, logFile string) {
-	// initialize the log file
-	dxfuse.MakeDxfuseBaseDir(cfg.options.MetadataDir)
-
 	logf := initLog(logFile)
 	logger := log.New(logf, "dxfuse: ", log.Flags())
 	logger.Printf("dxfuse version %s", dxfuse.Version)
@@ -508,8 +505,10 @@ func main() {
 	flag.Parse()
 	cfg := parseCmdLineArgs()
 	validateConfig(cfg)
+	dxfuse.MakeDxfuseBaseDir(cfg.options.MetadataDir)
 	logFile := filepath.Join(cfg.options.MetadataDir, dxfuse.LogFile)
 	fmt.Printf("The log file is located at %s\n", logFile)
+	// initialize the log file
 
 	dxda.UserAgent = fmt.Sprintf("dxfuse/%s (%s)", dxfuse.Version, runtime.GOOS)
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -477,6 +477,7 @@ func startDaemonAndWaitForInitializationToComplete(cfg Config, logFile string) {
 
 	// build the command line arguments for the daemon
 	daemonArgs := buildDaemonCommandLine(cfg, fullManifestPath)
+	fmt.Printf("daemonArgs=%v\n", daemonArgs)
 	mountCmd := exec.Command(progPath, daemonArgs...)
 	// Redirect stderr in case of go panic to write the stacktrace in the logfile
 	// Required since dxfuse daemon is a subprocess and not running in the foreground

--- a/cli/main.go
+++ b/cli/main.go
@@ -62,7 +62,7 @@ var (
 	gid          = flag.Int("gid", -1, "User group id (gid)")
 	verbose      = flag.Int("verbose", 0, "Enable verbose debugging")
 	version      = flag.Bool("version", false, "Print the version and exit")
-	metadataDir  = flag.String("metadataDir", getDefaultMetadataDir(), "Path to dxfuse metadata base directory. Defaults to $HOME/.dxfuse")
+	metadataDir  = flag.String("metadataDir", getDefaultMetadataDir(), "Directory to use for logfile and database. Defaults to $HOME/.dxfuse. Created if it does not exist.")
 )
 
 func lookupProject(dxEnv *dxda.DXEnvironment, projectIdOrName string) (string, error) {

--- a/cli/main.go
+++ b/cli/main.go
@@ -55,14 +55,14 @@ var (
 	debugFuseFlag = flag.Bool("debugFuse", false, "Tap into FUSE debugging information")
 	daemon        = flag.Bool("daemon", false, "An internal flag, do not use it")
 	// fsSync        = flag.Bool("sync", false, "Sychronize the filesystem and exit")
-	help             = flag.Bool("help", false, "display program options")
-	readOnly         = flag.Bool("readOnly", true, "DEPRECATED, now the default behavior. Mount the filesystem in read-only mode")
-	limitedWrite     = flag.Bool("limitedWrite", false, "Allow removing files and folders, creating files and appending to them. (Experimental, not recommended), default is read-only")
-	uid              = flag.Int("uid", -1, "User id (uid)")
-	gid              = flag.Int("gid", -1, "User group id (gid)")
-	verbose          = flag.Int("verbose", 0, "Enable verbose debugging")
-	version          = flag.Bool("version", false, "Print the version and exit")
-	dxfuseMetdataDir = flag.String("dxfuseMetdataDir", "", "Path to dxfuse metadata base directory. Defaults to $HOME/.dxfuse")
+	help         = flag.Bool("help", false, "display program options")
+	readOnly     = flag.Bool("readOnly", true, "DEPRECATED, now the default behavior. Mount the filesystem in read-only mode")
+	limitedWrite = flag.Bool("limitedWrite", false, "Allow removing files and folders, creating files and appending to them. (Experimental, not recommended), default is read-only")
+	uid          = flag.Int("uid", -1, "User id (uid)")
+	gid          = flag.Int("gid", -1, "User group id (gid)")
+	verbose      = flag.Int("verbose", 0, "Enable verbose debugging")
+	version      = flag.Bool("version", false, "Print the version and exit")
+	metdataDir   = flag.String("metdataDir", "", "Path to dxfuse metadata base directory. Defaults to $HOME/.dxfuse")
 )
 
 func lookupProject(dxEnv *dxda.DXEnvironment, projectIdOrName string) (string, error) {
@@ -287,8 +287,8 @@ func parseCmdLineArgs() Config {
 		os.Exit(2)
 	}
 	dxfuseBaseDir := ""
-	// if *metadataPath is empty string, then default to user homedir + .dxfuse
-	if *dxfuseMetdataDir == "" {
+	// if *metdataDir is empty string, then default to user homedir + .dxfuse
+	if *metdataDir == "" {
 		user, err := user.Current()
 		if err != nil {
 			log.Printf("error, could not describe the user")
@@ -296,7 +296,7 @@ func parseCmdLineArgs() Config {
 		}
 		dxfuseBaseDir = user.HomeDir + "/.dxfuse"
 	} else {
-		dxfuseBaseDir = *dxfuseMetdataDir
+		dxfuseBaseDir = *metdataDir
 	}
 
 	mountpoint := flag.Arg(0)
@@ -382,6 +382,7 @@ func startDaemon(cfg Config, logFile string) {
 	dxfuse.MakeDxfuseBaseDir(cfg.options.MetadataDir)
 	logf := initLog(logFile)
 	logger := log.New(logf, "dxfuse: ", log.Flags())
+	logger.Printf("dxfuse version %s", dxfuse.Version)
 
 	// Read the manifest from disk. It should already have all the fields
 	// filled in. There is no need to perform API calls.

--- a/cli/main.go
+++ b/cli/main.go
@@ -62,7 +62,7 @@ var (
 	gid          = flag.Int("gid", -1, "User group id (gid)")
 	verbose      = flag.Int("verbose", 0, "Enable verbose debugging")
 	version      = flag.Bool("version", false, "Print the version and exit")
-	metadataDir  = flag.String("metadataDir", getDefaultMetadataDir(), "Directory to use for logfile and database. Defaults to $HOME/.dxfuse. Created if it does not exist.")
+	metadataDir  = flag.String("metadataDir", getDefaultMetadataDir(), "Directory to use for dxfuse's internal metadata (log file, state database, etc). Created if does not exist. Defaults to "+getDefaultMetadataDir()+".")
 )
 
 func lookupProject(dxEnv *dxda.DXEnvironment, projectIdOrName string) (string, error) {
@@ -108,6 +108,7 @@ func getDefaultMetadataDir() string {
 	user, err := user.Current()
 	if err != nil {
 		log.Fatalf("error, could not describe the user: %v", err)
+		os.Exit(1)
 	}
 	return user.HomeDir + "/.dxfuse"
 }
@@ -508,7 +509,6 @@ func main() {
 	dxfuse.MakeDxfuseBaseDir(cfg.options.MetadataDir)
 	logFile := filepath.Join(cfg.options.MetadataDir, dxfuse.LogFile)
 	fmt.Printf("The log file is located at %s\n", logFile)
-	// initialize the log file
 
 	dxda.UserAgent = fmt.Sprintf("dxfuse/%s (%s)", dxfuse.Version, runtime.GOOS)
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -408,7 +408,9 @@ func buildDaemonCommandLine(cfg Config, fullManifestPath string) []string {
 	var daemonArgs []string
 	daemonArgs = append(daemonArgs, "-daemon")
 
-	daemonArgs = append(daemonArgs, []string{"-metadataDir", cfg.options.MetadataDir}...)
+	metadataArg := []string{"-metadataDir", cfg.options.MetadataDir}
+
+	daemonArgs = append(daemonArgs, metadataArg...)
 
 	if *debugFuseFlag {
 		daemonArgs = append(daemonArgs, "-debugFuse")

--- a/cli/main.go
+++ b/cli/main.go
@@ -495,6 +495,7 @@ func startDaemonAndWaitForInitializationToComplete(cfg Config, logFile string) {
 
 	// Wait for the tool to say the file system is ready.
 	fmt.Println("wait for ready")
+	fmt.Println("log file is at", logFile)
 	status := waitForReady(logFile)
 
 	if status == "error" {

--- a/cli/main.go
+++ b/cli/main.go
@@ -294,18 +294,6 @@ func parseCmdLineArgs() Config {
 		usage()
 		os.Exit(2)
 	}
-	// dxfuseBaseDir := ""
-	// // if *metadataDir is empty string, then default to user homedir + .dxfuse
-	// if *metadataDir == "" {
-	// 	user, err := user.Current()
-	// 	if err != nil {
-	// 		log.Printf("error, could not describe the user")
-	// 		os.Exit(1)
-	// 	}
-	// 	dxfuseBaseDir = user.HomeDir + "/.dxfuse"
-	// } else {
-	// 	dxfuseBaseDir = *metadataDir
-	// }
 
 	mountpoint := flag.Arg(0)
 
@@ -485,7 +473,6 @@ func startDaemonAndWaitForInitializationToComplete(cfg Config, logFile string) {
 
 	// build the command line arguments for the daemon
 	daemonArgs := buildDaemonCommandLine(cfg, fullManifestPath)
-	fmt.Printf("daemonArgs=%v\n", daemonArgs)
 	mountCmd := exec.Command(progPath, daemonArgs...)
 	// Redirect stderr in case of go panic to write the stacktrace in the logfile
 	// Required since dxfuse daemon is a subprocess and not running in the foreground
@@ -504,7 +491,6 @@ func startDaemonAndWaitForInitializationToComplete(cfg Config, logFile string) {
 
 	// Wait for the tool to say the file system is ready.
 	fmt.Println("wait for ready")
-	fmt.Println("log file is at", logFile)
 	status := waitForReady(logFile)
 
 	if status == "error" {

--- a/cli/main.go
+++ b/cli/main.go
@@ -62,7 +62,7 @@ var (
 	gid          = flag.Int("gid", -1, "User group id (gid)")
 	verbose      = flag.Int("verbose", 0, "Enable verbose debugging")
 	version      = flag.Bool("version", false, "Print the version and exit")
-	metdataDir   = flag.String("metdataDir", "", "Path to dxfuse metadata base directory. Defaults to $HOME/.dxfuse")
+	metadataDir  = flag.String("metadataDir", "", "Path to dxfuse metadata base directory. Defaults to $HOME/.dxfuse")
 )
 
 func lookupProject(dxEnv *dxda.DXEnvironment, projectIdOrName string) (string, error) {
@@ -287,8 +287,8 @@ func parseCmdLineArgs() Config {
 		os.Exit(2)
 	}
 	dxfuseBaseDir := ""
-	// if *metdataDir is empty string, then default to user homedir + .dxfuse
-	if *metdataDir == "" {
+	// if *metadataDir is empty string, then default to user homedir + .dxfuse
+	if *metadataDir == "" {
 		user, err := user.Current()
 		if err != nil {
 			log.Printf("error, could not describe the user")
@@ -296,7 +296,7 @@ func parseCmdLineArgs() Config {
 		}
 		dxfuseBaseDir = user.HomeDir + "/.dxfuse"
 	} else {
-		dxfuseBaseDir = *metdataDir
+		dxfuseBaseDir = *metadataDir
 	}
 
 	mountpoint := flag.Arg(0)

--- a/cli/main.go
+++ b/cli/main.go
@@ -62,7 +62,7 @@ var (
 	gid          = flag.Int("gid", -1, "User group id (gid)")
 	verbose      = flag.Int("verbose", 0, "Enable verbose debugging")
 	version      = flag.Bool("version", false, "Print the version and exit")
-	metadataDir  = flag.String("metadataDir", "", "Path to dxfuse metadata base directory. Defaults to $HOME/.dxfuse")
+	metadataDir  = flag.String("metadataDir", getDefaultMetadataDir(), "Path to dxfuse metadata base directory. Defaults to $HOME/.dxfuse")
 )
 
 func lookupProject(dxEnv *dxda.DXEnvironment, projectIdOrName string) (string, error) {
@@ -102,6 +102,14 @@ func getUser() user.User {
 		panic("asking the OS for the user returned nil")
 	}
 	return *user
+}
+
+func getDefaultMetadataDir() string {
+	user, err := user.Current()
+	if err != nil {
+		log.Fatalf("error, could not describe the user: %v", err)
+	}
+	return user.HomeDir + "/.dxfuse"
 }
 
 // Mount the filesystem:
@@ -286,18 +294,18 @@ func parseCmdLineArgs() Config {
 		usage()
 		os.Exit(2)
 	}
-	dxfuseBaseDir := ""
-	// if *metadataDir is empty string, then default to user homedir + .dxfuse
-	if *metadataDir == "" {
-		user, err := user.Current()
-		if err != nil {
-			log.Printf("error, could not describe the user")
-			os.Exit(1)
-		}
-		dxfuseBaseDir = user.HomeDir + "/.dxfuse"
-	} else {
-		dxfuseBaseDir = *metadataDir
-	}
+	// dxfuseBaseDir := ""
+	// // if *metadataDir is empty string, then default to user homedir + .dxfuse
+	// if *metadataDir == "" {
+	// 	user, err := user.Current()
+	// 	if err != nil {
+	// 		log.Printf("error, could not describe the user")
+	// 		os.Exit(1)
+	// 	}
+	// 	dxfuseBaseDir = user.HomeDir + "/.dxfuse"
+	// } else {
+	// 	dxfuseBaseDir = *metadataDir
+	// }
 
 	mountpoint := flag.Arg(0)
 
@@ -308,7 +316,7 @@ func parseCmdLineArgs() Config {
 		VerboseLevel: *verbose,
 		Uid:          uid,
 		Gid:          gid,
-		MetadataDir:  dxfuseBaseDir,
+		MetadataDir:  *metadataDir,
 	}
 
 	dxEnv, _, err := dxda.GetDxEnvironment()

--- a/cli/main.go
+++ b/cli/main.go
@@ -380,6 +380,7 @@ func parseManifest(cfg Config) (*dxfuse.Manifest, error) {
 func startDaemon(cfg Config, logFile string) {
 	// initialize the log file
 	dxfuse.MakeDxfuseBaseDir(cfg.options.MetadataDir)
+
 	logf := initLog(logFile)
 	logger := log.New(logf, "dxfuse: ", log.Flags())
 	logger.Printf("dxfuse version %s", dxfuse.Version)
@@ -406,6 +407,8 @@ func startDaemon(cfg Config, logFile string) {
 func buildDaemonCommandLine(cfg Config, fullManifestPath string) []string {
 	var daemonArgs []string
 	daemonArgs = append(daemonArgs, "-daemon")
+
+	daemonArgs = append(daemonArgs, "-metadataDir", cfg.options.MetadataDir)
 
 	if *debugFuseFlag {
 		daemonArgs = append(daemonArgs, "-debugFuse")

--- a/cli/main.go
+++ b/cli/main.go
@@ -408,7 +408,7 @@ func buildDaemonCommandLine(cfg Config, fullManifestPath string) []string {
 	var daemonArgs []string
 	daemonArgs = append(daemonArgs, "-daemon")
 
-	daemonArgs = append(daemonArgs, "-metadataDir", cfg.options.MetadataDir)
+	daemonArgs = append(daemonArgs, []string{"-metadataDir", cfg.options.MetadataDir}...)
 
 	if *debugFuseFlag {
 		daemonArgs = append(daemonArgs, "-debugFuse")

--- a/dxfuse.go
+++ b/dxfuse.go
@@ -148,7 +148,6 @@ func NewDxfuse(
 		httpIoPool <- dxda.NewHttpClient()
 	}
 
-	dxfuseBaseDir := MakeFSBaseDir()
 	fsys := &Filesys{
 		dxEnv:          dxEnv,
 		options:        options,
@@ -167,7 +166,7 @@ func NewDxfuse(
 	}
 
 	// Create a fresh SQL database
-	databaseFile := filepath.Join(dxfuseBaseDir, DatabaseFile)
+	databaseFile := filepath.Join(options.MetadataDir, DatabaseFile)
 	fsys.log("Removing old version of the database (%s)", databaseFile)
 	if err := os.RemoveAll(databaseFile); err != nil {
 		fsys.log("error removing old database %s", err.Error())

--- a/dxfuse.go
+++ b/dxfuse.go
@@ -166,7 +166,7 @@ func NewDxfuse(
 	}
 
 	// Create a fresh SQL database
-	databaseFile := filepath.Join(options.MetadataDir, DatabaseFile)
+	databaseFile := filepath.Join(options.StateFolder, DatabaseFile)
 	fsys.log("Removing old version of the database (%s)", databaseFile)
 	if err := os.RemoveAll(databaseFile); err != nil {
 		fsys.log("error removing old database %s", err.Error())

--- a/test/local/local.sh
+++ b/test/local/local.sh
@@ -24,3 +24,6 @@ faux_dirs
 
 source $CRNT_DIR/file_overwrite.sh
 file_overwrite
+
+source $CRNT_DIR/multiple_mounts.sh
+multiple_mounts

--- a/test/local/multiple_mounts.sh
+++ b/test/local/multiple_mounts.sh
@@ -2,6 +2,7 @@ CRNT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 projName="dxfuse_test_data"
 dxfuse="$CRNT_DIR/../../dxfuse"
 baseDir=$HOME/dxfuse_test
+state_folder="$baseDir/.dxfusebase"
 mountpoint0=${baseDir}/MNT
 mountpoint1=${baseDir}/MNT1
 
@@ -17,6 +18,7 @@ function teardown {
     cd $HOME
     fusermount -u $mountpoint
     fusermount -u $mountpoint1
+    rm -rf $state_folder
 }
 
 # trap any errors and cleanup
@@ -29,7 +31,6 @@ function multiple_mounts {
     # mount dxfuse with default folder path
     $dxfuse $mountpoint0 $projName
 
-    state_folder="$baseDir/.dxfusebase"
     # mount dxfuse with a different folder path
     $dxfuse -stateFolder $state_folder $mountpoint1 $projName
 
@@ -45,7 +46,9 @@ function multiple_mounts {
     # check that two dxfuse mounts are present
     mount_count=$(mount | grep -c dxfuse)
     if [[ $mount_count -eq 2 ]]; then
-        echo "Two dxfuse mounts are present."
+        echo "Two dxfuse mounts are present"
+        echo "Mounts:"
+        mount | grep dxfuse
     else
         echo "Error: Expected 2 dxfuse mounts, but found $mount_count."
         exit 1
@@ -53,16 +56,16 @@ function multiple_mounts {
 
     # check that dxfuse state files exist in both folders
     if [[ -f $state_folder/dxfuse.log ]]; then
-        echo "Log file exists in $state_folder"
+        echo "Log file exists with -stateFolder arg $state_folder"
     else
         echo "Log file does not exist in $state_folder"
         exit 1
     fi
 
-    if [[ -f "$HOME/dxfuse.log" ]]; then
-        echo "Log file exists in $HOME"
+    if [[ -f /root/.dxfuse/dxfuse.log ]]; then
+        echo "Log file exists with default -stateFolder path"
     else
-        echo "Log file not exist in $HOME"
+        echo "Log file not exist in /root/.dxfuse"
         exit 1
     fi
 

--- a/test/local/multiple_mounts.sh
+++ b/test/local/multiple_mounts.sh
@@ -69,11 +69,5 @@ function multiple_mounts {
         exit 1
     fi
 
-    # check that the mounts are the same
-    if ! diff <(ls -l "$mountpoint0/$projName") <(ls -l "$mountpoint1/$projName"); then
-        echo "Error: The two mounts are different."
-        exit 1
-    fi
-
     teardown
 }

--- a/test/local/multiple_mounts.sh
+++ b/test/local/multiple_mounts.sh
@@ -70,7 +70,7 @@ function multiple_mounts {
     fi
 
     # check that the mounts are the same
-    if ! diff <(ls -l $mountpoint0) <(ls -l $mountpoint1); then
+    if ! diff <(ls -l "$mountpoint0/$projName") <(ls -l "$mountpoint1/$projName"); then
         echo "Error: The two mounts are different."
         exit 1
     fi

--- a/test/local/multiple_mounts.sh
+++ b/test/local/multiple_mounts.sh
@@ -29,9 +29,9 @@ function multiple_mounts {
     # mount dxfuse with default folder path
     $dxfuse $mountpoint0 $projName
 
-    folder_path="$baseDir/.dxfusebase"
+    state_folder="$baseDir/.dxfusebase"
     # mount dxfuse with a different folder path
-    $dxfuse -folderPath $folder_path $mountpoint1 $projName
+    $dxfuse -stateFolder $state_folder $mountpoint1 $projName
 
     # check that two dxfuse processes are running
     dxfuse_process_count=$(pgrep -c dxfuse)
@@ -48,6 +48,21 @@ function multiple_mounts {
         echo "Two dxfuse mounts are present."
     else
         echo "Error: Expected 2 dxfuse mounts, but found $mount_count."
+        exit 1
+    fi
+
+    # check that dxfuse state files exist in both folders
+    if [[ -f $state_folder/dxfuse.log ]]; then
+        echo "Log file exists in $state_folder"
+    else
+        echo "Log file does not exist in $state_folder"
+        exit 1
+    fi
+
+    if [[ -f "$HOME/dxfuse.log" ]]; then
+        echo "Log file exists in $HOME"
+    else
+        echo "Log file not exist in $HOME"
         exit 1
     fi
 

--- a/test/local/multiple_mounts.sh
+++ b/test/local/multiple_mounts.sh
@@ -1,0 +1,61 @@
+CRNT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+projName="dxfuse_test_data"
+dxfuse="$CRNT_DIR/../../dxfuse"
+baseDir=$HOME/dxfuse_test
+mountpoint0=${baseDir}/MNT
+mountpoint1=${baseDir}/MNT1
+
+# cleanup sequence
+function teardown {
+    if [[ $teardown_complete == 1 ]]; then
+        return
+    fi
+    teardown_complete=1
+
+
+    echo "unmounting dxfuse"
+    cd $HOME
+    fusermount -u $mountpoint
+    fusermount -u $mountpoint1
+}
+
+# trap any errors and cleanup
+trap teardown EXIT
+
+function multiple_mounts {
+    mkdir -p $mountpoint0
+    mkdir -p $mountpoint1
+
+    # mount dxfuse with default folder path
+    $dxfuse $mountpoint0 $projName
+
+    folder_path="$baseDir/.dxfusebase"
+    # mount dxfuse with a different folder path
+    $dxfuse -folderPath $folder_path $mountpoint1 $projName
+
+    # check that two dxfuse processes are running
+    dxfuse_process_count=$(pgrep -c dxfuse)
+    if [[ $dxfuse_process_count -eq 2 ]]; then
+        echo "Two dxfuse processes are running."
+    else
+        echo "Error: Expected 2 dxfuse processes, but found $dxfuse_process_count."
+        exit 1
+    fi
+
+    # check that two dxfuse mounts are present
+    mount_count=$(mount | grep -c dxfuse)
+    if [[ $mount_count -eq 2 ]]; then
+        echo "Two dxfuse mounts are present."
+    else
+        echo "Error: Expected 2 dxfuse mounts, but found $mount_count."
+        exit 1
+    fi
+
+    # check that the mounts are the same
+    if ! diff <(ls -l $mountpoint0) <(ls -l $mountpoint1); then
+        echo "Error: The two mounts are different."
+        exit 1
+    fi
+
+    teardown
+}

--- a/util.go
+++ b/util.go
@@ -321,11 +321,11 @@ func MakeDxfuseBaseDir(dxfuseBaseDir string) string {
 	if _, err := os.Stat(dxfuseBaseDir); err != nil {
 		if os.IsNotExist(err) {
 			if err := os.Mkdir(dxfuseBaseDir, 0700); err != nil {
-				log.Fatalf("Failed to create directory %s: %v", dxfuseBaseDir, err)
+				log.Fatalf("Failed to create state directory %s: %v", dxfuseBaseDir, err)
 				os.Exit(1)
 			}
 		} else {
-			log.Fatalf("Failed to stat directory %s: %v", dxfuseBaseDir, err)
+			log.Fatalf("Failed to create state directory %s: %v", dxfuseBaseDir, err)
 			os.Exit(1)
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/user"
 	"time"
 
 	"github.com/jacobsa/fuse/fuseops"
@@ -71,6 +70,7 @@ type Options struct {
 	VerboseLevel int
 	Uid          uint32
 	Gid          uint32
+	MetadataDir  string
 }
 
 // A node is a generalization over files and directories
@@ -316,14 +316,8 @@ func intToBool(x int) bool {
 	return false
 }
 
-// create a directory for all the dxfuse files in  $HOME/.dxfuse
-func MakeFSBaseDir() string {
-	user, err := user.Current()
-	if err != nil {
-		log.Printf("error, could not describe the user")
-		os.Exit(1)
-	}
-	dxfuseBaseDir := user.HomeDir + "/.dxfuse"
+// create a directory for all dxfuse files. Manifest, log, sqlite db, etc.
+func MakeDxfuseBaseDir(dxfuseBaseDir string) string {
 	if _, err := os.Stat(dxfuseBaseDir); os.IsNotExist(err) {
 		os.Mkdir(dxfuseBaseDir, 0700)
 	}

--- a/util.go
+++ b/util.go
@@ -70,7 +70,7 @@ type Options struct {
 	VerboseLevel int
 	Uid          uint32
 	Gid          uint32
-	MetadataDir  string
+	StateFolder  string
 }
 
 // A node is a generalization over files and directories
@@ -318,8 +318,16 @@ func intToBool(x int) bool {
 
 // create a directory for all dxfuse files. Manifest, log, sqlite db, etc.
 func MakeDxfuseBaseDir(dxfuseBaseDir string) string {
-	if _, err := os.Stat(dxfuseBaseDir); os.IsNotExist(err) {
-		os.Mkdir(dxfuseBaseDir, 0700)
+	if _, err := os.Stat(dxfuseBaseDir); err != nil {
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(dxfuseBaseDir, 0700); err != nil {
+				log.Fatalf("Failed to create directory %s: %v", dxfuseBaseDir, err)
+				os.Exit(1)
+			}
+		} else {
+			log.Fatalf("Failed to stat directory %s: %v", dxfuseBaseDir, err)
+			os.Exit(1)
+		}
 	}
 	return dxfuseBaseDir
 }


### PR DESCRIPTION
Allow user to specify directory path where logfile, db, and manifest file are written. Still defaults to `$HOME/.dxfuse` if not provided.