### PR TITLE
COMPUTE-1544 add tgid check in writefile

### DIFF
--- a/dxfuse.go
+++ b/dxfuse.go
@@ -1495,6 +1495,13 @@ func (fsys *Filesys) WriteFile(ctx context.Context, op *fuseops.WriteFileOp) err
 	if fh.accessMode != AM_AO_Remote {
 		return syscall.EPERM
 	}
+
+	tgid, _ := GetTgid(op.OpContext.Pid)
+	if fh.Tgid != tgid {
+		fsys.log("Ignoring WriteFile: tgids does not match fh tgid")
+		return syscall.EPERM
+	}
+
 	// One write at a time per fh so that sequential offsets work properly
 	fh.mutex.Lock()
 	defer fh.mutex.Unlock()


### PR DESCRIPTION
if more than one processes is writing using the same shared file handler, only the one that create the file can close and flush it properly. The other processes that also writes to the file cannot close it with `syscall.EPERM` but the content are already appended and uploaded.